### PR TITLE
Implement Product Details Screen with navigation

### DIFF
--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ActionButtonsSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ActionButtonsSection.kt
@@ -1,0 +1,42 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.component
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Message
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ActionButtonsSection() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        OutlinedButton(
+            onClick = { /* Handle message action */ },
+            modifier = Modifier.weight(1f)
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Message,
+                    contentDescription = "Message"
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(text = "Message")
+            }
+        }
+        Button(
+            onClick = { /* Handle make offer action */ },
+            modifier = Modifier.weight(1f),
+            colors = ButtonDefaults.buttonColors(containerColor =  MaterialTheme.colorScheme.primary)
+        ) {
+            Text(text = "Make Offer")
+        }
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/DescriptionSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/DescriptionSection.kt
@@ -1,0 +1,40 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DescriptionSection() {
+    Column(
+        modifier = Modifier.padding(16.dp)
+    ) {
+        Text(
+            text = "Description",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.Bold
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Selling my MacBook Pro M2 in perfect condition. Only 3 months old, includes original box and charger. No scratch excellent condition. MacBook Pro M2 model A152678 with good condition...",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+        )
+
+        Text(
+            text = "Read More",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductImageSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductImageSection.kt
@@ -1,0 +1,88 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.CachePolicy
+import coil.request.ImageRequest
+import coil.size.Size
+import kotlinx.coroutines.delay
+
+@Composable
+fun ProductImageSection(
+    imageUrls: List<String>,
+    onBackClick: () -> Unit = {},
+) {
+    var currentImageIndex by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(key1 = imageUrls) {
+        if (imageUrls.size > 1) {
+            while (true) {
+                delay(3000)
+                currentImageIndex = (currentImageIndex + 1) % imageUrls.size
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(300.dp)
+    ) {
+        CachedUserImage(
+            imageUrl = imageUrls[currentImageIndex],
+            modifier = Modifier.fillMaxSize()
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.ArrowBack,
+                contentDescription = "Back",
+                tint = Color.Black,
+                modifier = Modifier.clickable { onBackClick() }
+            )
+
+            Icon(
+                imageVector = Icons.Default.Share,
+                contentDescription = "Share",
+                tint = Color.Black
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(bottom = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            imageUrls.forEachIndexed { index, _ ->
+                Box(
+                    modifier = Modifier
+                        .size(8.dp)
+                        .clip(CircleShape)
+                        .background(if (index == currentImageIndex) Color.White else Color.Gray)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductInfoSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductInfoSection.kt
@@ -1,0 +1,79 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun ProductInfoSection() {
+    Column(
+        modifier = Modifier.padding(16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "MacBook Pro M2",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold
+            )
+            Text(
+                text = "$1,499",
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Bold
+            )
+        }
+
+        Text(
+            text = "Listed 2 hours ago",
+            style = MaterialTheme.typography.bodySmall,
+            color = Color.Gray
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            Chip(text = "512GB SSD")
+            Chip(text = "16GB RAM")
+            Chip(text = "2020 Model")
+            Chip(text = "Space Gray")
+        }
+    }
+}
+
+@Composable
+fun Chip(text: String) {
+    Surface(
+        modifier = Modifier.padding(2.dp),
+        shape = RoundedCornerShape(8.dp),
+        color = Color.LightGray
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            color = Color.DarkGray
+        )
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ScrapCard.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ScrapCard.kt
@@ -23,7 +23,7 @@ fun ScrapCard(
     user: User,
     scrap: ScrapItem,
     onBuyClick: () -> Unit = {},
-    onDetailsClick: () -> Unit = {},
+    onDetailsClick: (id:Int) -> Unit = {},
     systemIsRtl: Boolean = false
 ) {
     Card(
@@ -112,7 +112,7 @@ fun ScrapCard(
                     modifier = Modifier.fillMaxWidth().padding(top = 16.dp)
                 ) {
                     OutlinedButton(
-                        onClick = onDetailsClick,
+                        onClick = { onDetailsClick(scrap.id) },
                         shape = RoundedCornerShape(8.dp),
                         modifier = Modifier.weight(1f)
                     ) {

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/SellerInfoSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/SellerInfoSection.kt
@@ -1,0 +1,70 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.component
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Verified
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SellerInfoSection(
+    userImage: String?,
+    userName: String,
+    isVerified: Boolean,
+    rating: Double,
+    reviewCount: Int
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CachedUserImage(userImage)
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        Column {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = userName,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Icon(
+                    imageVector = if (isVerified) Icons.Default.Verified else Icons.Default.Person,
+                    contentDescription = "Verified",
+                    tint = Color.Blue
+                )
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.Star,
+                    contentDescription = "Star rating",
+                    tint = Color.Yellow
+                )
+                Text(
+                    text =  rating.toString(),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.Gray
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = "($reviewCount reviews)",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.Gray
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/MarketScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/MarketScreen.kt
@@ -30,7 +30,7 @@ import com.delighted2wins.souqelkhorda.features.market.presentation.component.Se
 @Composable
 fun MarketScreen(
     onBuyClick: () -> Unit = {},
-    onDetailsClick: () -> Unit = {}
+    onDetailsClick: (Int) -> Unit = {}
 ) {
     var query by remember { mutableStateOf("") }
     val isRtl: Boolean = LocalLayoutDirection.current == LayoutDirection.Rtl
@@ -76,7 +76,9 @@ fun MarketScreen(
                 user = user ?: User(0, "مستخدم مجهول", "غير معروف"),
                 scrapData,
                 onBuyClick = { /* Handle buy action */ },
-                onDetailsClick = { /* Handle details action */ },
+                onDetailsClick = {
+                    onDetailsClick(scrapData.id)
+                },
                 systemIsRtl  = isRtl,
             )
         }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/ProductDetailsScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/ProductDetailsScreen.kt
@@ -1,0 +1,57 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.screen
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.*
+
+@Composable
+fun ProductDetailsScreen(
+    productId: Int,
+    onBackClick: () -> Unit = {}
+) {
+    val imageUrls = listOf(
+        "https://images.unsplash.com/photo-1542393359-994b1509a25b?q=80&w=2670&auto=format&fit=crop",
+        "https://images.unsplash.com/photo-1517336714731-489689fd1e86?q=80&w=2574&auto=format&fit=crop",
+        "https://images.unsplash.com/photo-1611095790444-16a73c1503e7?q=80&w=2670&auto=format&fit=crop",
+        "https://images.unsplash.com/photo-1611095790444-16a73c1503e7?q=80&w=2670&auto=format&fit=crop",
+        "https://images.unsplash.com/photo-1517336714731-489689fd1e86?q=80&w=2574&auto=format&fit=crop"
+    )
+
+    Surface(
+        color = Color.Transparent,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = 16.dp)
+        ) {
+            ProductImageSection(
+                imageUrls = imageUrls,
+                onBackClick = { onBackClick() }
+            )
+            ProductInfoSection()
+            DescriptionSection()
+            SellerInfoSection(
+                userImage = "https://avatar.iran.liara.run/public/boy?username=Scott",
+                userName = "John Doe",
+                isVerified = true,
+                rating = 4.8,
+                reviewCount = 120
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            ActionButtonsSection()
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun ProductDetailsScreenPreview() {
+    ProductDetailsScreen(0)
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/navigation/MyScreens.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/navigation/MyScreens.kt
@@ -18,3 +18,7 @@ data object LoginScreen:NavKey
 
 @Serializable
 data object SignUpScreen:NavKey
+
+@Serializable
+data class ProductDetailsKey(val productId: Int) : NavKey
+

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/navigation/NavigationRoot.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavEntry
-import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSavedStateNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import androidx.navigation3.ui.rememberSceneSetupNavEntryDecorator
@@ -17,6 +16,7 @@ import com.delighted2wins.souqelkhorda.features.sale.presentation.screen.DirectS
 import com.delighted2wins.souqelkhorda.features.sign_up.presentation.screen.SignUpScreen
 import com.delighted2wins.souqelkhorda.features.splash.SplashScreen
 import com.delighted2wins.souqelkhorda.login.presentation.screen.LoginScreen
+import com.delighted2wins.souqelkhorda.features.market.presentation.screen.ProductDetailsScreen
 
 @Composable
 fun NavigationRoot(
@@ -48,7 +48,24 @@ fun NavigationRoot(
                 MarketScreen -> {
                     NavEntry(key) {
                         bottomBarState.value = true
-                        MarketScreen()
+                        MarketScreen(
+                            onBuyClick = {
+                                // Navigate to Buying Screen
+                            },
+                            onDetailsClick = { orderId ->
+                                backStack.add(ProductDetailsKey(orderId))
+                            }
+                        )
+                    }
+                }
+
+                is ProductDetailsKey -> {
+                    NavEntry(key) {
+                        bottomBarState.value = false
+                        ProductDetailsScreen(
+                            productId = key.productId,
+                            onBackClick = { backStack.remove(key) }
+                        )
                     }
                 }
 


### PR DESCRIPTION
Key changes:
- Added `ProductDetailsKey` to `MyScreens.kt` for navigation to product details, accepting a `productId`.
- Modified `NavigationRoot.kt` to handle navigation to `ProductDetailsScreen` when a product is selected in `MarketScreen` and to handle back navigation from `ProductDetailsScreen`. The bottom bar is hidden on the details screen.
- Updated `ScrapCard.kt` and `MarketScreen.kt` to pass the `scrap.id` or `scrapData.id` respectively when `onDetailsClick` is invoked.
- Created `ProductImageSection.kt` to display a carousel of product images with back and share icons, and image indicator dots.
- Created `ProductInfoSection.kt` to display product name, price, listing time, and chips for product specifications.
- Created `DescriptionSection.kt` to show product description with a "Read More" option.
- Created `SellerInfoSection.kt` to display seller's image, name, verification status, rating, and review count.
- Created `ActionButtonsSection.kt` with "Message" and "Make Offer" buttons.
- Implemented `ProductDetailsScreen.kt` which composes the newly created sections (`ProductImageSection`, `ProductInfoSection`, `DescriptionSection`, `SellerInfoSection`, `ActionButtonsSection`) and handles back navigation.