### PR TITLE
Refactor Market and ProductDetails components and screens

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/core/components/CachedUserImage.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/core/components/CachedUserImage.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component
+package com.delighted2wins.souqelkhorda.core.components
 
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/data/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/data/dummy.kt
@@ -1,0 +1,2 @@
+package com.delighted2wins.souqelkhorda.features.market.data
+

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/Market/ScrapCard.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/Market/ScrapCard.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.Market
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -17,6 +17,7 @@ import com.delighted2wins.souqelkhorda.core.utils.getTimeAgo
 import com.delighted2wins.souqelkhorda.core.utils.isArabic
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapItem
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.User
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.ProductDetails.ScrapUserSection
 
 @Composable
 fun ScrapCard(

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/Market/SearchBar.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/Market/SearchBar.kt
@@ -1,9 +1,11 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.Market
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.AlertDialogDefaults.shape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -11,14 +13,9 @@ import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.input.OffsetMapping
-import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.delighted2wins.souqelkhorda.app.theme.Til
 
@@ -47,7 +44,9 @@ fun SearchBar(
         } else null,
         singleLine = true,
         shape = RoundedCornerShape(24.dp),
-        modifier = modifier.height(56.dp),
+        modifier = modifier
+            .height(56.dp)
+            .border(width = 1.dp, color = Til, shape = shape),
         colors = TextFieldDefaults.colors(
             focusedContainerColor = Color.White,
             unfocusedContainerColor = Color.White,
@@ -69,7 +68,6 @@ fun SearchBar(
 fun SearchBarPreviewLTR() {
     SearchBar(query = "", onQueryChange = {}, isRtl = false)
 }
-
 
 @Preview(showBackground = true)
 @Composable

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/ActionButtonsSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/ActionButtonsSection.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.ProductDetails
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
@@ -7,7 +7,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 @Composable

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/DescriptionSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/DescriptionSection.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.ProductDetails
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/ProductImageSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/ProductImageSection.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.ProductDetails
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -13,13 +13,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
-import coil.request.CachePolicy
-import coil.request.ImageRequest
-import coil.size.Size
+import com.delighted2wins.souqelkhorda.core.components.CachedUserImage
 import kotlinx.coroutines.delay
 
 @Composable

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/ProductInfoSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/ProductInfoSection.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.ProductDetails
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/ScrapUserSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/ScrapUserSection.kt
@@ -1,7 +1,6 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.ProductDetails
 
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -9,13 +8,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import coil.compose.AsyncImage
+import com.delighted2wins.souqelkhorda.core.components.CachedUserImage
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapStatus
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.User
 

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/SellerInfoSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/SellerInfoSection.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.ProductDetails
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.delighted2wins.souqelkhorda.core.components.CachedUserImage
 
 @Composable
 fun SellerInfoSection(

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/MarketScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/MarketScreen.kt
@@ -1,7 +1,9 @@
 package com.delighted2wins.souqelkhorda.features.market.presentation.screen
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -24,11 +26,12 @@ import com.delighted2wins.souqelkhorda.app.theme.Til
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapItem
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapStatus
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.User
-import com.delighted2wins.souqelkhorda.features.market.presentation.component.ScrapCard
-import com.delighted2wins.souqelkhorda.features.market.presentation.component.SearchBar
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.Market.ScrapCard
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.Market.SearchBar
 
 @Composable
 fun MarketScreen(
+    innerPadding: PaddingValues = PaddingValues(),
     onBuyClick: () -> Unit = {},
     onDetailsClick: (Int) -> Unit = {}
 ) {
@@ -39,7 +42,11 @@ fun MarketScreen(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .padding(12.dp),
+            .padding(
+                top = innerPadding.calculateTopPadding(),
+              //  bottom = innerPadding.calculateBottomPadding()
+            ),
+        contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         item {
@@ -82,6 +89,9 @@ fun MarketScreen(
                 systemIsRtl  = isRtl,
             )
         }
+        item {
+            Spacer(modifier = Modifier.padding(60.dp))
+        }
     }
 }
 
@@ -92,11 +102,6 @@ fun sampleData() = listOf(
     ScrapItem(3, "Iron Scrap", "Pieces of old iron...", "الإسكندرية", 50, quantity = 5, status = ScrapStatus.Waiting, date = "2025-09-12", userId = 102),
     ScrapItem(4, "Copper & Wires", "Used copper wires...", "طنطا", 15, status = ScrapStatus.Available, date = "2025-09-01", userId = 103),
     ScrapItem(5, "زجاج مستعمل", "زجاج معاد التدوير...", "Mansoura", 20, status = ScrapStatus.Reserved, date = "2025-09-02", userId = 104)
-)
-
-fun dummyTags() = listOf(
-    "A",
-    "P",
 )
 
 fun sampleUser() = listOf(

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/ProductDetailsScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/ProductDetailsScreen.kt
@@ -7,10 +7,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.delighted2wins.souqelkhorda.features.market.presentation.component.*
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.ProductDetails.ActionButtonsSection
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.ProductDetails.DescriptionSection
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.ProductDetails.ProductImageSection
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.ProductDetails.ProductInfoSection
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.ProductDetails.SellerInfoSection
 
 @Composable
 fun ProductDetailsScreen(
+    innerPadding: PaddingValues = PaddingValues(),
     productId: Int,
     onBackClick: () -> Unit = {}
 ) {
@@ -24,7 +29,9 @@ fun ProductDetailsScreen(
 
     Surface(
         color = Color.Transparent,
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(innerPadding)
     ) {
         Column(
             modifier = Modifier
@@ -53,5 +60,5 @@ fun ProductDetailsScreen(
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun ProductDetailsScreenPreview() {
-    ProductDetailsScreen(0)
+    // ProductDetailsScreen(innerPadding = Unit, productId = 1)
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/navigation/NavigationRoot.kt
@@ -61,6 +61,7 @@ fun NavigationRoot(
                     NavEntry(key) {
                         bottomBarState.value = true
                         MarketScreen(
+                            innerPadding,
                             onBuyClick = {
                                 // Navigate to Buying Screen
                             },
@@ -75,6 +76,7 @@ fun NavigationRoot(
                     NavEntry(key) {
                         bottomBarState.value = false
                         ProductDetailsScreen(
+                            innerPadding,
                             productId = key.productId,
                             onBackClick = { backStack.remove(key) }
                         )


### PR DESCRIPTION
This commit refactors the Market and ProductDetails features by:
- Moving UI components into dedicated sub-packages:
    - `ScrapCard.kt` and `SearchBar.kt` moved to `features.market.presentation.component.Market`.
    - `DescriptionSection.kt`, `ActionButtonsSection.kt`, `ProductInfoSection.kt`, `ProductImageSection.kt`, `SellerInfoSection.kt`, and `ScrapUserSection.kt` moved to `features.market.presentation.component.ProductDetails`.
- Moving `CachedUserImage.kt` to `core.components`.
- Updating `MarketScreen.kt` and `ProductDetailsScreen.kt` to accept `innerPadding` to handle system UI elements like status and navigation bars. This padding is applied to the main content area.
- In `MarketScreen.kt`:
    - Added `contentPadding` to the `LazyColumn`.
    - Added a `Spacer` at the end of the `LazyColumn` to prevent content from being hidden behind the bottom navigation bar.
    - Removed `dummyTags()` function.
- In `NavigationRoot.kt`:
    - Passed `innerPadding` from `Scaffold` to `MarketScreen` and `ProductDetailsScreen`.
- In `ScrapCard.kt`:
    - Updated import for `ScrapUserSection`.
- In `ProductImageSection.kt`:
    - Updated import for `CachedUserImage`.
- In `SellerInfoSection.kt`:
    - Updated import for `CachedUserImage`.
- In `ScrapUserSection.kt`:
    - Updated import for `CachedUserImage`.
- In `SearchBar.kt`:
    - Added a border to the `TextField`.
