### PR TITLE
Refactor ScrapCard and enhance sample data

### DIFF
--- a/app/src/main/java/com/delighted2wins/souqelkhorda/core/utils/TimeUtils.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/core/utils/TimeUtils.kt
@@ -17,37 +17,37 @@ fun getTimeAgo(dateString: String, isArabic: Boolean = true): String {
         if (isArabic) {
             when {
                 daysBetween == 0L -> "اليوم"
-                daysBetween == 1L -> "منذ يوم واحد"
+                daysBetween == 1L -> "منذ يوم"
                 daysBetween < 7 -> "منذ $daysBetween أيام"
                 daysBetween < 30 -> {
                     val weeks = daysBetween / 7
-                    "منذ $weeks أسبوع${if (weeks > 1) "ان" else ""}"
+                    if (weeks == 1L) "منذ أسبوع" else "منذ $weeks أسابيع"
                 }
                 daysBetween < 365 -> {
                     val months = daysBetween / 30
-                    "منذ $months شهر${if (months > 1) "ًا" else ""}"
+                    if (months == 1L) "منذ شهر" else "منذ $months أشهر"
                 }
                 else -> {
                     val years = daysBetween / 365
-                    "منذ $years سنة${if (years > 1) "ً" else ""}"
+                    if (years == 1L) "منذ سنة" else "منذ $years سنوات"
                 }
             }
         } else {
             when {
                 daysBetween == 0L -> "Today"
-                daysBetween == 1L -> "1 day ago"
+                daysBetween == 1L -> "day ago"
                 daysBetween < 7 -> "$daysBetween days ago"
                 daysBetween < 30 -> {
                     val weeks = daysBetween / 7
-                    "$weeks week${if (weeks > 1) "s" else ""} ago"
+                    if (weeks == 1L) "week ago" else "$weeks weeks ago"
                 }
                 daysBetween < 365 -> {
                     val months = daysBetween / 30
-                    "$months month${if (months > 1) "s" else ""} ago"
+                    if (months == 1L) "month ago" else "$months months ago"
                 }
                 else -> {
                     val years = daysBetween / 365
-                    "$years year${if (years > 1) "s" else ""} ago"
+                    if (years == 1L) "year ago" else "$years years ago"
                 }
             }
         }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/domain/entities/ScrapItem.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/domain/entities/ScrapItem.kt
@@ -7,9 +7,11 @@ data class ScrapItem(
     val title: String,
     val description: String,
     val location: String,
+    val price: Double,
     val weight: Int,
     val quantity: Int? = null,
     val status: ScrapStatus,
     val date: String,
+    val images: List<String>? = null,
     val userId: Int,
 )

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/Market/ScrapCard.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/Market/ScrapCard.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -36,8 +37,8 @@ fun ScrapCard(
 
             ScrapUserSection(
                 userData = user,
-                status = scrap.status,
-                isRtl = systemIsRtl
+                date = scrap.date,
+                systemIsRtl = systemIsRtl
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -67,7 +68,7 @@ fun ScrapCard(
                     textAlign = TextAlign.Start
                 )
 
-                Spacer(modifier = Modifier.height(12.dp))
+                Spacer(modifier = Modifier.height(24.dp))
 
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -79,7 +80,7 @@ fun ScrapCard(
                         style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
                         color = MaterialTheme.colorScheme.primary,
                         textAlign = TextAlign.Start,
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(.6f)
                     )
 
                     scrap.quantity?.let {
@@ -89,17 +90,23 @@ fun ScrapCard(
                             style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
                             color = MaterialTheme.colorScheme.primary,
                             textAlign = TextAlign.Start,
-                            modifier = Modifier.weight(1f)
+                            modifier = Modifier.weight(.6f)
                         )
+                    }
+                    if (scrap.quantity == null) {
+                        Spacer(modifier = Modifier.weight(.6f))
                     }
 
                     DirectionalText(
-                        text = getTimeAgo(scrap.date, systemIsRtl),
+                        text = if (systemIsRtl) "السعر: ${scrap.price} ج.م" else "Price: ${scrap.price} EGP",
                         contentIsRtl = systemIsRtl,
-                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
-                        color = MaterialTheme.colorScheme.secondary.copy(alpha = 2f),
+                        style = MaterialTheme.typography.bodyMedium.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontSize = MaterialTheme.typography.bodyLarge.fontSize,
+                        ),
+                        color = Color.Red,
                         textAlign = TextAlign.End,
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(.8f)
                     )
                 }
             }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/ScrapUserSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ProductDetails/ScrapUserSection.kt
@@ -10,18 +10,21 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.delighted2wins.souqelkhorda.core.components.CachedUserImage
+import com.delighted2wins.souqelkhorda.core.components.DirectionalText
+import com.delighted2wins.souqelkhorda.core.utils.getTimeAgo
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapStatus
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.User
 
 @Composable
 fun ScrapUserSection(
     userData : User,
-    status: ScrapStatus,
-    isRtl: Boolean = false
+    date: String,
+    systemIsRtl: Boolean = false
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -51,19 +54,29 @@ fun ScrapUserSection(
             }
         }
 
-        Surface(
-            color = status.color,
-            shape = RoundedCornerShape(8.dp),
-            modifier = Modifier.padding(start = 8.dp)
-        ) {
-            Text(
-                text = if (isRtl) status.labelAr else status.labelEn,
-                style = MaterialTheme.typography.titleMedium,
-                color = Color.White,
-                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
-            )
+        DirectionalText(
+            text = getTimeAgo(date, systemIsRtl),
+            contentIsRtl = systemIsRtl,
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+            color = MaterialTheme.colorScheme.scrim.copy(alpha = .4f),
+            textAlign = TextAlign.End,
+            modifier = Modifier.fillMaxWidth()
+        )
+
+//        Surface(
+//            color = status.color,
+//            shape = RoundedCornerShape(8.dp),
+//            modifier = Modifier.padding(start = 8.dp)
+//        ) {
+//            Text(
+//                text = if (isRtl) status.labelAr else status.labelEn,
+//                style = MaterialTheme.typography.titleMedium,
+//                color = Color.White,
+//                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+//            )
+//         {
+
         }
-    }
 }
 
 
@@ -76,5 +89,5 @@ fun ScrapUserSectionPreview() {
         location = "الجيزة - الدقي",
         imageUrl = "https://avatar.iran.liara.run/public/boy?username=Scott"
     )
-    ScrapUserSection(user,ScrapStatus.Waiting, isRtl = false)
+    ScrapUserSection(user,"9/9/2009", systemIsRtl = false)
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/MarketScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/MarketScreen.kt
@@ -42,10 +42,7 @@ fun MarketScreen(
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .padding(
-                top = innerPadding.calculateTopPadding(),
-              //  bottom = innerPadding.calculateBottomPadding()
-            ),
+            .padding(top = innerPadding.calculateTopPadding()),
         contentPadding = PaddingValues(16.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
@@ -97,20 +94,187 @@ fun MarketScreen(
 
 
 fun sampleData() = listOf(
-    ScrapItem(1, "Plastic & Aluminum", "Mixed scrap materials...", "Cairo - Maadi", 25, quantity = 5,status = ScrapStatus.Available, date = "2025-09-10", userId = 100),
-    ScrapItem(2, "ورق وكرتون مكتبي", "أوراق مكتبية متنوعة...", "Giza - Dokki", 30, quantity = 3, status = ScrapStatus.Sold, date = "2025-09-05", userId = 101),
-    ScrapItem(3, "Iron Scrap", "Pieces of old iron...", "الإسكندرية", 50, quantity = 5, status = ScrapStatus.Waiting, date = "2025-09-12", userId = 102),
-    ScrapItem(4, "Copper & Wires", "Used copper wires...", "طنطا", 15, status = ScrapStatus.Available, date = "2025-09-01", userId = 103),
-    ScrapItem(5, "زجاج مستعمل", "زجاج معاد التدوير...", "Mansoura", 20, status = ScrapStatus.Reserved, date = "2025-09-02", userId = 104)
+    ScrapItem(
+        id = 1,
+        title = "Plastic & Aluminum",
+        description = "Mixed scrap materials...",
+        location = "Cairo - Maadi",
+        price = 25.0,
+        weight = 12,
+        quantity = 5,
+        status = ScrapStatus.Available,
+        date = "2025-09-10",
+        userId = 100
+    ),
+    ScrapItem(
+        id = 2,
+        title = "ورق وكرتون مكتبي",
+        description = "أوراق مكتبية متنوعة...",
+        location = "Giza - Dokki",
+        price = 30.0,
+        weight = 8,
+        quantity = 3,
+        status = ScrapStatus.Sold,
+        date = "2025-09-05",
+        userId = 101
+    ),
+    ScrapItem(
+        id = 3,
+        title = "Iron Scrap",
+        description = "Pieces of old iron...",
+        location = "الإسكندرية",
+        price = 50.0,
+        weight = 20,
+        quantity = 5,
+        status = ScrapStatus.Waiting,
+        date = "2025-09-12",
+        userId = 102
+    ),
+    ScrapItem(
+        id = 4,
+        title = "Copper & Wires",
+        description = "Used copper wires...",
+        location = "طنطا",
+        price = 15.0,
+        weight = 10,
+        status = ScrapStatus.Available,
+        date = "2025-09-01",
+        userId = 103
+    ),
+    ScrapItem(
+        id = 5,
+        title = "زجاج مستعمل",
+        description = "زجاج معاد التدوير...",
+        location = "Mansoura",
+        price = 20.0,
+        weight = 7,
+        status = ScrapStatus.Reserved,
+        date = "2025-09-02",
+        userId = 104
+    ),
+    ScrapItem(
+        id = 6,
+        title = "Wood Pieces",
+        description = "Old wooden furniture parts...",
+        location = "Cairo - Nasr City",
+        price = 18.0,
+        weight = 15,
+        quantity = 4,
+        status = ScrapStatus.Available,
+        date = "2025-09-08",
+        userId = 105
+    ),
+    ScrapItem(
+        id = 7,
+        title = "Electronic Boards",
+        description = "Broken circuit boards...",
+        location = "Giza - Haram",
+        price = 40.0,
+        weight = 6,
+        quantity = 2,
+        status = ScrapStatus.Waiting,
+        date = "2025-09-11",
+        userId = 106
+    ),
+    ScrapItem(
+        id = 8,
+        title = "Car Batteries",
+        description = "Used car batteries for recycling...",
+        location = "Cairo - Shubra",
+        price = 60.0,
+        weight = 25,
+        quantity = 3,
+        status = ScrapStatus.Sold,
+        date = "2025-09-03",
+        userId = 107
+    ),
+    ScrapItem(
+        id = 9,
+        title = "Textile Waste",
+        description = "Fabric and textile leftovers...",
+        location = "Alexandria - Sidi Gaber",
+        price = 12.0,
+        weight = 9,
+        quantity = 6,
+        status = ScrapStatus.Reserved,
+        date = "2025-09-04",
+        userId = 108
+    ),
+    ScrapItem(
+        id = 10,
+        title = "Mixed Metals",
+        description = "Combination of various metals...",
+        location = "Cairo - Helwan",
+        price = 55.0,
+        weight = 18,
+        quantity = 5,
+        status = ScrapStatus.Available,
+        date = "2025-09-09",
+        userId = 109
+    )
 )
 
 fun sampleUser() = listOf(
-    User(100, "Ahmed Mohamed", "Cairo - Maadi", "https://avatar.iran.liara.run/public/boy?username=Scott"),
-    User(101, "فاطمة أحمد", "Giza - Dokki", "https://avatar.iran.liara.run/public/girl?username=Maria"),
-    User(102, "Mohamed Ali", "Alexandria", "https://avatar.iran.liara.run/public/boy?username=Scott"),
-    User(103, "سارة محمود", "طنطا", "https://avatar.iran.liara.run/public/girl?username=Maria"),
-    User(104, "Mohamed Mahmoud", "طنطا") // No image URL
+    User(
+        id = 100,
+        name = "Ahmed Mohamed",
+        location = "Cairo - Maadi",
+        imageUrl = "https://avatar.iran.liara.run/public/boy?username=Ahmed"
+    ),
+    User(
+        id = 101,
+        name = "فاطمة أحمد",
+        location = "Giza - Dokki",
+        imageUrl = "https://avatar.iran.liara.run/public/girl?username=Fatma"
+    ),
+    User(
+        id = 102,
+        name = "Mohamed Ali",
+        location = "Alexandria",
+        imageUrl = "https://avatar.iran.liara.run/public/boy?username=Mohamed"
+    ),
+    User(
+        id = 103,
+        name = "سارة محمود",
+        location = "Tanta",
+        imageUrl = "https://avatar.iran.liara.run/public/girl?username=Sara"
+    ),
+    User(
+        id = 104,
+        name = "Mohamed Mahmoud",
+        location = "Mansoura" // No image URL
+    ),
+    User(
+        id = 105,
+        name = "Youssef Adel",
+        location = "Cairo - Nasr City",
+        imageUrl = "https://avatar.iran.liara.run/public/boy?username=Youssef"
+    ),
+    User(
+        id = 106,
+        name = "Mona Hassan",
+        location = "Giza - Haram",
+        imageUrl = "https://avatar.iran.liara.run/public/girl?username=Mona"
+    ),
+    User(
+        id = 107,
+        name = "Omar Khaled",
+        location = "Cairo - Shubra",
+        imageUrl = "https://avatar.iran.liara.run/public/boy?username=Omar"
+    ),
+    User(
+        id = 108,
+        name = "Layla Ibrahim",
+        location = "Alexandria - Sidi Gaber",
+        imageUrl = "https://avatar.iran.liara.run/public/girl?username=Layla"
+    ),
+    User(
+        id = 109,
+        name = "Hassan Tarek",
+        location = "Cairo - Helwan" // No image URL
+    )
 )
+
 
 
 @Preview(showBackground = true, showSystemUi = true)


### PR DESCRIPTION
Key changes:
- In `ScrapCard.kt`:
    - Changed `ScrapUserSection` to display the scrap item's date instead of its status.
    - Adjusted spacing and layout weights for better visual balance.
    - Updated the display of price, making it more prominent with red color and bold font.
    - If quantity is null, a spacer is now added to maintain layout consistency.
- In `ScrapItem.kt` (domain entity):
    - Added `price` (Double) and `images` (List<String>?) fields.
- In `ScrapUserSection.kt`:
    - Modified to accept `date` and `systemIsRtl` instead of `status` and `isRtl`.
    - Now displays the time ago using `getTimeAgo` utility.
    - Removed the display of scrap status.
- In `MarketScreen.kt`:
    - Expanded `sampleData()` for `ScrapItem` to include more diverse items with the new `price` field.
    - Expanded `sampleUser()` to include more users.
    - Removed bottom padding from `LazyColumn` for a cleaner look.
- In `TimeUtils.kt`:
    - Refined the logic in `getTimeAgo` for more natural language output in both English and Arabic (e.g., "week ago" instead of "1 week ago", "منذ أسبوع" instead of "منذ 1 أسبوعان").