### PR TITLE
Implement Market feature with Firebase backend

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,7 +4,7 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-09-14T10:35:21.348742800Z">
+        <DropdownSelection timestamp="2025-09-16T17:27:33.738796500Z">
           <Target type="DEFAULT_BOOT">
             <handle>
               <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\youss\.android\avd\Pixel_9.avd" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,8 @@ dependencies {
 
     // firebase
     implementation(platform("com.google.firebase:firebase-bom:34.2.0"))
+    implementation("com.google.firebase:firebase-firestore:24.10.0")
+    implementation("com.google.firebase:firebase-auth:24.0.1")
 
     //extended icons
     implementation (libs.androidx.compose.material.icons.extended)

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/app/App.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/app/App.kt
@@ -1,7 +1,15 @@
 package com.delighted2wins.souqelkhorda.app
 
 import android.app.Application
+import com.google.firebase.FirebaseApp
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class App : Application()
+class App : Application(){
+    override fun onCreate() {
+        super.onCreate()
+        if (FirebaseApp.getApps(this).isEmpty()) {
+            FirebaseApp.initializeApp(this)
+        }
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/core/di/FirebaseModule.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/core/di/FirebaseModule.kt
@@ -1,0 +1,15 @@
+package com.delighted2wins.souqelkhorda.core.di
+
+import com.google.firebase.firestore.FirebaseFirestore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object FirebaseModule {
+
+    @Provides
+    fun provideFirestore(): FirebaseFirestore = FirebaseFirestore.getInstance()
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/data/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/data/dummy.kt
@@ -1,2 +1,0 @@
-package com.delighted2wins.souqelkhorda.features.market.data
-

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/data/model/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/data/model/dummy.kt
@@ -1,0 +1,2 @@
+package com.delighted2wins.souqelkhorda.features.market.data.model
+

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/data/remote/MarketRemoteDataSource.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/data/remote/MarketRemoteDataSource.kt
@@ -1,0 +1,17 @@
+package com.delighted2wins.souqelkhorda.features.market.data.remote
+
+import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrder
+import com.google.firebase.firestore.FirebaseFirestore
+import javax.inject.Inject
+import kotlinx.coroutines.tasks.await
+
+class MarketRemoteDataSource @Inject constructor(
+    private val firestore: FirebaseFirestore
+) {
+    suspend fun fetchScrapOrders(): List<ScrapOrder> {
+        val snapshot = firestore.collection("scrap_orders").get().await()
+        return snapshot.documents.mapNotNull { doc ->
+            doc.toObject(ScrapOrder::class.java)
+        }
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/data/repository/MarketRepositoryImpl.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/data/repository/MarketRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.delighted2wins.souqelkhorda.features.market.data.repository
+
+import com.delighted2wins.souqelkhorda.features.market.data.remote.MarketRemoteDataSource
+import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrder
+import com.delighted2wins.souqelkhorda.features.market.domain.repository.MarketRepository
+import javax.inject.Inject
+
+class MarketRepositoryImpl @Inject constructor(
+    private val remoteDataSource: MarketRemoteDataSource
+) : MarketRepository {
+
+    override suspend fun getScrapOrders(): List<ScrapOrder> {
+        return remoteDataSource.fetchScrapOrders()
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/di/MarketModule.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/di/MarketModule.kt
@@ -1,0 +1,29 @@
+package com.delighted2wins.souqelkhorda.features.market.di
+
+import com.delighted2wins.souqelkhorda.features.market.data.remote.MarketRemoteDataSource
+import com.delighted2wins.souqelkhorda.features.market.data.repository.MarketRepositoryImpl
+import com.delighted2wins.souqelkhorda.features.market.domain.repository.MarketRepository
+import com.delighted2wins.souqelkhorda.features.market.domain.usecase.GetScrapOrdersUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object MarketModule {
+
+    @Provides
+    @ViewModelScoped
+    fun provideMarketRepository(
+        remoteDataSource: MarketRemoteDataSource
+    ): MarketRepository = MarketRepositoryImpl(remoteDataSource)
+
+    @Provides
+    @ViewModelScoped
+    fun provideGetScrapOrdersUseCase(
+        repository: MarketRepository
+    ): GetScrapOrdersUseCase = GetScrapOrdersUseCase(repository)
+
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/di/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/di/dummy.kt
@@ -1,2 +1,0 @@
-package com.delighted2wins.souqelkhorda.features.market.di
-

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/domain/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/domain/dummy.kt
@@ -1,2 +1,0 @@
-package com.delighted2wins.souqelkhorda.features.market.domain
-

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/domain/repository/MarketRepository.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/domain/repository/MarketRepository.kt
@@ -1,0 +1,7 @@
+package com.delighted2wins.souqelkhorda.features.market.domain.repository
+
+import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrder
+
+interface MarketRepository {
+    suspend fun getScrapOrders(): List<ScrapOrder>
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/domain/usecase/GetScrapOrdersUseCase.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/domain/usecase/GetScrapOrdersUseCase.kt
@@ -1,0 +1,10 @@
+package com.delighted2wins.souqelkhorda.features.market.domain.usecase
+
+import com.delighted2wins.souqelkhorda.features.market.domain.repository.MarketRepository
+import javax.inject.Inject
+
+class GetScrapOrdersUseCase @Inject constructor(
+    private val repository: MarketRepository
+) {
+    suspend operator fun invoke() = repository.getScrapOrders()
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/market/ScrapCard.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/market/ScrapCard.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component.Market
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.market
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -17,7 +17,7 @@ import com.delighted2wins.souqelkhorda.core.components.DirectionalText
 import com.delighted2wins.souqelkhorda.core.utils.isArabic
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrder
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.User
-import com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails.ScrapUserSection
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails.ScrapUserSection
 
 @Composable
 fun ScrapCard(

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/market/SearchBar.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/market/SearchBar.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component.Market
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.market
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.height

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/ActionButtonsSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/ActionButtonsSection.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/DescriptionSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/DescriptionSection.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -8,7 +8,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/ExpandableDescription.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/ExpandableDescription.kt
@@ -1,11 +1,10 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/OrderDetailsTopBar.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/OrderDetailsTopBar.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/OrderItemCard.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/OrderItemCard.kt
@@ -1,10 +1,7 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails
 
 import android.annotation.SuppressLint
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -12,13 +9,9 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberAsyncImagePainter
-import com.delighted2wins.souqelkhorda.core.components.CachedUserImage
 import com.delighted2wins.souqelkhorda.core.components.DirectionalText
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrderItem
 

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/ProductImageSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/ProductImageSection.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/ProductInfoSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/ProductInfoSection.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/ScrapUserSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/ScrapUserSection.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/SellerInfoSection.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/SellerInfoSection.kt
@@ -1,9 +1,8 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Verified
 import androidx.compose.material3.*

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/ZoomableImageList.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/orderdetails/ZoomableImageList.kt
@@ -1,4 +1,4 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails
+package com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.transformable

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/market/MarketEffect.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/market/MarketEffect.kt
@@ -1,0 +1,8 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.contract.market
+
+import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrder
+
+sealed class MarketEffect {
+    data class NavigateToOrderDetails(val order: ScrapOrder): MarketEffect()
+    data class ShowError(val message: String): MarketEffect()
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/market/MarketIntents.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/market/MarketIntents.kt
@@ -1,0 +1,9 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.contract.market
+
+import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrder
+
+sealed class MarketIntent {
+    object LoadScrapOrders: MarketIntent()
+    data class SearchQueryChanged(val query: String): MarketIntent()
+    data class ClickOrder(val order: ScrapOrder): MarketIntent()
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/market/MarketState.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/market/MarketState.kt
@@ -1,0 +1,10 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.contract.market
+
+import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrder
+
+data class MarketState(
+    val isLoading: Boolean = false,
+    val scrapOrders: List<ScrapOrder> = emptyList(),
+    val query: String = "",
+    val error: String? = null
+)

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/orderdetails/OrderDetailsEffect.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/orderdetails/OrderDetailsEffect.kt
@@ -1,0 +1,4 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.contract.orderdetails
+
+class OrderDetailsEffect {
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/orderdetails/OrderDetailsIntents.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/orderdetails/OrderDetailsIntents.kt
@@ -1,0 +1,4 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.contract.orderdetails
+
+class OrderDetailsIntents {
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/orderdetails/OrderDetailsState.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/orderdetails/OrderDetailsState.kt
@@ -1,0 +1,4 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.contract.orderdetails
+
+class OrderDetailsState {
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/OrderDetailsScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/OrderDetailsScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -25,11 +24,11 @@ import androidx.compose.ui.unit.dp
 import com.delighted2wins.souqelkhorda.core.components.DirectionalText
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrder
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.User
-import com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails.OrderItemCard
-import com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails.ActionButtonsSection
-import com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails.DescriptionSection
-import com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails.OrderDetailsTopBar
-import com.delighted2wins.souqelkhorda.features.market.presentation.component.OrderDetails.SellerInfoSection
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails.OrderItemCard
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails.ActionButtonsSection
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails.DescriptionSection
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails.OrderDetailsTopBar
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.orderdetails.SellerInfoSection
 
 @Composable
 fun OrderDetailsScreen(

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/state/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/state/dummy.kt
@@ -1,2 +1,0 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.state
-

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/viewmodel/MarketViewModel.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/viewmodel/MarketViewModel.kt
@@ -1,0 +1,62 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.screen
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.delighted2wins.souqelkhorda.features.market.domain.usecase.GetScrapOrdersUseCase
+import com.delighted2wins.souqelkhorda.features.market.presentation.contract.market.MarketEffect
+import com.delighted2wins.souqelkhorda.features.market.presentation.contract.market.MarketIntent
+import com.delighted2wins.souqelkhorda.features.market.presentation.contract.market.MarketState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MarketViewModel @Inject constructor(
+    private val getScrapOrdersUseCase: GetScrapOrdersUseCase
+) : ViewModel() {
+
+    var state by mutableStateOf(MarketState())
+        private set
+
+    private val _effect = MutableSharedFlow<MarketEffect>()
+    val effect = _effect.asSharedFlow()
+
+    init {
+        loadOrders()
+    }
+
+    fun onIntent(intent: MarketIntent) {
+        when (intent) {
+            is MarketIntent.LoadScrapOrders -> loadOrders()
+            is MarketIntent.SearchQueryChanged -> {
+                state = state.copy(query = intent.query)
+            }
+            is MarketIntent.ClickOrder -> {
+                viewModelScope.launch {
+                    _effect.emit(MarketEffect.NavigateToOrderDetails(intent.order))
+                }
+            }
+        }
+    }
+
+    private fun loadOrders() {
+        viewModelScope.launch {
+            state = state.copy(isLoading = true)
+            try {
+                val orders = getScrapOrdersUseCase()
+                state = state.copy(
+                    isLoading = false,
+                    scrapOrders = orders
+                )
+            } catch (e: Exception) {
+                state = state.copy(isLoading = false)
+                _effect.emit(MarketEffect.ShowError(e.message ?: "Unknown error"))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/viewmodel/OrderDetailsViewModel.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/viewmodel/OrderDetailsViewModel.kt
@@ -1,0 +1,16 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import com.delighted2wins.souqelkhorda.features.sale.presentation.SaleState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+@HiltViewModel
+class OrderDetailsViewModel@Inject constructor(
+
+): ViewModel() {
+    private var _state = MutableStateFlow(SaleState())
+    val state = _state
+
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/viewmodel/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/viewmodel/dummy.kt
@@ -1,2 +1,0 @@
-package com.delighted2wins.souqelkhorda.features.market.presentation.viewmodel
-

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/navigation/MyScreens.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/navigation/MyScreens.kt
@@ -1,12 +1,10 @@
 package com.delighted2wins.souqelkhorda.navigation
 
 import android.os.Parcelable
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation3.runtime.NavKey
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrder
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
-
 
 @Serializable
 data object DirectSaleScreen:NavKey

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ lifecycleViewmodelNav3 = "1.0.0-alpha01"
 kotlinSerialization = "2.1.21"
 kotlinxSerializationCore = "1.8.1"
 roomCompiler = "2.8.0"
+firebaseFirestoreKtx = "26.0.0"
 
 [libraries]
 androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
@@ -41,6 +42,7 @@ androidx-navigation3-ui = { module = "androidx.navigation3:navigation3-ui", vers
 # Optional add-on libraries
 androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecycle-viewmodel-navigation3", version.ref = "lifecycleViewmodelNav3" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerializationCore" }
+firebase-firestore-ktx = { group = "com.google.firebase", name = "firebase-firestore-ktx", version.ref = "firebaseFirestoreKtx" }
 
 
 [plugins]


### PR DESCRIPTION

Key changes:
- **Firebase Integration:**
    - Added `firebase-firestore-ktx` dependency to `app/build.gradle.kts` and `gradle/libs.versions.toml`.
    - Initialized FirebaseApp in the `App` class.
    - Created `FirebaseModule.kt` to provide `FirebaseFirestore` instance.
- **Market Feature Implementation:**
    - **Data Layer:**
        - Added `MarketRemoteDataSource.kt` to fetch scrap orders from Firestore.
        - Implemented `MarketRepositoryImpl.kt` and `MarketRepository.kt` for data abstraction.
        - Moved dummy data package from `features/market/data/dummy.kt` to `features/market/data/model/dummy.kt`.
    - **Domain Layer:**
        - Created `GetScrapOrdersUseCase.kt` to handle business logic for fetching orders.
        - Deleted `features/market/domain/dummy.kt`.
    - **Presentation Layer:**
        - **ViewModel:**
            - Renamed `dummy.kt` to `MarketViewModel.kt` and implemented MVI pattern for managing MarketScreen state, intents, and effects.
            - Added `OrderDetailsViewModel.kt` (currently basic).
        - **Contracts (State, Intent, Effect):**
            - Created `MarketState.kt`, `MarketIntents.kt`, and `MarketEffect.kt` for the Market screen.
            - Created placeholder contract files for OrderDetails: `OrderDetailsState.kt`, `OrderDetailsIntents.kt`, `OrderDetailsEffect.kt`.
        - **Screens:**
            - Updated `MarketScreen.kt` to use `MarketViewModel` to load and display scrap orders. It now handles search queries and navigation to order details.
            - `OrderDetailsScreen.kt` remains largely unchanged functionally but package structure for its components was updated.
        - **Components:**
            - Renamed and moved component packages from `features/market/presentation/component/Market` to `features/market/presentation/component/market` and `features/market/presentation/component/OrderDetails` to `features/market/presentation/component/orderdetails`.
            - `ScrapCard.kt` now correctly references `ScrapUserSection.kt` from the new package.
            - Minor cleanup in `OrderItemCard.kt` by removing unused imports.
    - **Dependency Injection:**
        - Renamed `dummy.kt` in `features/market/di` to `MarketModule.kt` and provided dependencies for repository and use case.
