### PR TITLE
feat(myorders): Implement My Orders screen with tabbed navigation

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,6 +13,20 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
+      <SelectionState runConfigName="ProfileScreenPreview">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="MarketScreenPreview">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-09-18T21:35:37.119139400Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\youss\.android\avd\Pixel_9.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/MarketScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/MarketScreen.kt
@@ -34,7 +34,7 @@ import kotlin.collections.listOf
 fun MarketScreen(
     innerPadding: PaddingValues = PaddingValues(),
     viewModel: MarketViewModel = hiltViewModel(),
-    onBuyClick: () -> Unit = {},
+    navigateToMakeOffer: () -> Unit = {},
     onDetailsClick: (ScrapOrder) -> Unit
 ) {
     val state = viewModel.state
@@ -98,7 +98,7 @@ fun MarketScreen(
                     location = scrapData.location
                 ),
                 scrap = scrapData,
-                onBuyClick = { onBuyClick() },
+                onBuyClick = { navigateToMakeOffer() },
                 onDetailsClick = { onDetailsClick(scrapData) },
                 systemIsRtl = isRtl
             )

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/data/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/data/dummy.kt
@@ -1,0 +1,2 @@
+package com.delighted2wins.souqelkhorda.features.myorders.data
+

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/di/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/di/dummy.kt
@@ -1,0 +1,2 @@
+package com.delighted2wins.souqelkhorda.features.myorders.di
+

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/domain/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/domain/dummy.kt
@@ -1,0 +1,2 @@
+package com.delighted2wins.souqelkhorda.features.myorders.domain
+

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/component/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/component/dummy.kt
@@ -1,0 +1,2 @@
+package com.delighted2wins.souqelkhorda.features.myorders.presentation.component
+

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/screen/MarketOrdersScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/screen/MarketOrdersScreen.kt
@@ -1,0 +1,25 @@
+package com.delighted2wins.souqelkhorda.features.myorders.presentation.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+
+@Composable
+fun MarketOrdersScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Market Orders", fontSize = 22.sp, fontWeight = FontWeight.Bold)
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/screen/OrdersScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/screen/OrdersScreen.kt
@@ -1,0 +1,99 @@
+package com.delighted2wins.souqelkhorda.features.myorders.presentation.screen
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun OrdersScreen(
+    innerPadding: PaddingValues = PaddingValues(),
+    onBackClick: () -> Unit
+) {
+    val tabs = listOf("Sale" to 2, "Market" to 5)
+    val pagerState = rememberPagerState(initialPage = 0, pageCount = { tabs.size })
+    val scope = rememberCoroutineScope()
+
+
+    LaunchedEffect(pagerState.currentPage) {
+        when (pagerState.currentPage) {
+            0 -> {
+                // Example: viewModel.loadSaleOrders()
+            }
+            1 -> {
+                // Example: viewModel.loadMarketOrders()
+            }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+            .padding(innerPadding)
+    ) {
+        TabRow(
+            selectedTabIndex = pagerState.currentPage,
+            containerColor = Color.White,
+            contentColor = Color.Black
+        ) {
+            tabs.forEachIndexed { index, (title, count) ->
+                val isSelected = pagerState.currentPage == index
+
+                Tab(
+                    selected = isSelected,
+                    onClick = {
+                        scope.launch { pagerState.animateScrollToPage(index) }
+                    },
+                    text = {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            Text(
+                                text = title,
+                                fontSize = 16.sp,
+                                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                                color = if (isSelected) Color.Black else Color.Gray
+                            )
+
+                            if (count > 0) {
+                                Badge(
+                                    containerColor = Color.Red,
+                                    contentColor = Color.White
+                                ) {
+                                    Text(
+                                        text = count.toString(),
+                                        fontSize = 12.sp
+                                    )
+                                }
+                            }
+                        }
+                    }
+                )
+            }
+        }
+
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxSize()
+        ) { page ->
+            when (page) {
+                0 -> SaleOrdersScreen()
+                1 -> MarketOrdersScreen()
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/screen/SaleOrdersScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/screen/SaleOrdersScreen.kt
@@ -1,0 +1,24 @@
+package com.delighted2wins.souqelkhorda.features.myorders.presentation.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun SaleOrdersScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text("Sale Orders", fontSize = 22.sp, fontWeight = FontWeight.Bold)
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/viewmodel/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/viewmodel/dummy.kt
@@ -1,0 +1,2 @@
+package com.delighted2wins.souqelkhorda.features.myorders.presentation.viewmodel
+

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/navigation/NavigationRoot.kt
@@ -16,6 +16,7 @@ import com.delighted2wins.souqelkhorda.features.buyers.presentation.screen.Neare
 import com.delighted2wins.souqelkhorda.features.market.presentation.screen.MarketScreen
 import com.delighted2wins.souqelkhorda.features.sale.presentation.screen.SaleScreen
 import com.delighted2wins.souqelkhorda.features.market.presentation.screen.OrderDetailsScreen
+import com.delighted2wins.souqelkhorda.features.myorders.presentation.screen.OrdersScreen
 import com.delighted2wins.souqelkhorda.features.profile.presentation.screen.ProfileScreen
 import com.delighted2wins.souqelkhorda.features.sign_up.presentation.screen.SignUpScreen
 import com.delighted2wins.souqelkhorda.features.splash.SplashScreen
@@ -65,7 +66,7 @@ fun NavigationRoot(
                         bottomBarState.value = true
                         MarketScreen(
                             innerPadding,
-                            onBuyClick = {
+                            navigateToMakeOffer = {
                                 // Navigate to Buying Screen
                             },
                             onDetailsClick = { order ->
@@ -139,6 +140,16 @@ fun NavigationRoot(
                     NavEntry(key) {
                         bottomBarState.value = false
                         ProfileScreen(
+                            onBackClick = { backStack.remove(key) },
+                        )
+                    }
+                }
+
+                OrdersScreen -> {
+                    NavEntry(key) {
+                        bottomBarState.value = true
+                        OrdersScreen(
+                            innerPadding,
                             onBackClick = { backStack.remove(key) },
                         )
                     }


### PR DESCRIPTION

This commit introduces the "My Orders" screen, which features a tabbed interface for "Sale" and "Market" orders.

Key changes:
- Added `OrdersScreen.kt` to display a tabbed layout for managing different types of orders. It uses a `HorizontalPager` to switch between "Sale" and "Market" views.
- Implemented `SaleOrdersScreen.kt` as a placeholder screen for sale orders.
- Implemented `MarketOrdersScreen.kt` as a placeholder screen for market orders.
- Updated `NavigationRoot.kt` to include navigation to the new `OrdersScreen`.
- In `MarketScreen.kt`, renamed the `onBuyClick` parameter to `navigateToMakeOffer` for clarity.
- Added dummy files in `di`, `data`, `domain`, `presentation/component`, `presentation/contract` and `presentation/viewmodel` packages within the `myorders` feature for future development.
