### PR TITLE
Refactor Market screen and add pull-to-refresh and shimmer effect

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,7 +65,6 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
 
     //navigation3
-
     implementation(libs.androidx.navigation3.ui)
     implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.lifecycle.viewmodel.navigation3)
@@ -99,4 +98,10 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     ksp(libs.androidx.room.compiler)
     implementation(libs.androidx.room.ktx)
+
+    // accompanist placeholder (shimmer)
+    implementation("com.google.accompanist:accompanist-placeholder-material3:0.32.0")
+    // accompanist swipe refresh
+    implementation("com.google.accompanist:accompanist-swiperefresh:0.32.0")
+
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/core/di/FirebaseModule.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/core/di/FirebaseModule.kt
@@ -17,5 +17,6 @@ object FirebaseModule {
     fun provideFirebaseAuth(): FirebaseAuth = FirebaseAuth.getInstance()
 
     @Provides
+    @Singleton
     fun provideFirestore(): FirebaseFirestore = FirebaseFirestore.getInstance()
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ScrapCardShimmer.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/component/ScrapCardShimmer.kt
@@ -1,0 +1,146 @@
+package com.delighted2wins.souqelkhorda.features.market.presentation.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.google.accompanist.placeholder.PlaceholderHighlight
+import com.google.accompanist.placeholder.material3.placeholder
+import com.google.accompanist.placeholder.material3.shimmer
+
+@Composable
+fun ScrapCardShimmer(
+    systemIsRtl: Boolean = false
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(4.dp)
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+
+            // User section shimmer (avatar + name)
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 12.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .placeholder(
+                            visible = true,
+                            highlight = PlaceholderHighlight.shimmer(),
+                            color = MaterialTheme.colorScheme.surfaceVariant
+                        )
+                )
+                Column(modifier = Modifier.weight(1f)) {
+                    Box(
+                        modifier = Modifier
+                            .height(16.dp)
+                            .fillMaxWidth(.5f)
+                            .placeholder(
+                                visible = true,
+                                highlight = PlaceholderHighlight.shimmer(),
+                                color = MaterialTheme.colorScheme.surfaceVariant
+                            )
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Box(
+                        modifier = Modifier
+                            .height(14.dp)
+                            .fillMaxWidth(.3f)
+                            .placeholder(
+                                visible = true,
+                                highlight = PlaceholderHighlight.shimmer(),
+                                color = MaterialTheme.colorScheme.surfaceVariant
+                            )
+                    )
+                }
+            }
+
+            // Title shimmer
+            Box(
+                modifier = Modifier
+                    .height(20.dp)
+                    .fillMaxWidth(.8f)
+                    .placeholder(
+                        visible = true,
+                        highlight = PlaceholderHighlight.shimmer(),
+                        color = MaterialTheme.colorScheme.surfaceVariant
+                    )
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // Description shimmer (3 lines)
+            repeat(3) {
+                Box(
+                    modifier = Modifier
+                        .height(14.dp)
+                        .fillMaxWidth()
+                        .padding(bottom = 6.dp)
+                        .placeholder(
+                            visible = true,
+                            highlight = PlaceholderHighlight.shimmer(),
+                            color = MaterialTheme.colorScheme.surfaceVariant
+                        )
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            // Price shimmer
+            Box(
+                modifier = Modifier
+                    .height(18.dp)
+                    .fillMaxWidth(.4f)
+                    .align(
+                        if (systemIsRtl)
+                            androidx.compose.ui.Alignment.Start
+                        else
+                            androidx.compose.ui.Alignment.End
+                    )
+                    .placeholder(
+                        visible = true,
+                        highlight = PlaceholderHighlight.shimmer(),
+                        color = MaterialTheme.colorScheme.surfaceVariant
+                    )
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Buttons shimmer
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Box(
+                    modifier = Modifier
+                        .height(40.dp)
+                        .weight(1f)
+                        .placeholder(
+                            visible = true,
+                            highlight = PlaceholderHighlight.shimmer(),
+                            color = MaterialTheme.colorScheme.surfaceVariant
+                        )
+                )
+                Box(
+                    modifier = Modifier
+                        .height(40.dp)
+                        .weight(1f)
+                        .placeholder(
+                            visible = true,
+                            highlight = PlaceholderHighlight.shimmer(),
+                            color = MaterialTheme.colorScheme.surfaceVariant
+                        )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/MarketIntents.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/MarketIntents.kt
@@ -4,6 +4,7 @@ import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrde
 
 sealed class MarketIntent {
     object LoadScrapOrders: MarketIntent()
+    object Refresh: MarketIntent()
     data class SearchQueryChanged(val query: String): MarketIntent()
     data class ClickOrder(val order: ScrapOrder): MarketIntent()
     object SellNowClicked: MarketIntent()

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/MarketState.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/contract/MarketState.kt
@@ -4,7 +4,8 @@ import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrde
 
 data class MarketState(
     val isLoading: Boolean = false,
-    val scrapOrders: List<ScrapOrder> = emptyList(),
+    val isRefreshing: Boolean = false,
+    val successfulOrders: List<ScrapOrder> = emptyList(),
     val query: String = "",
     val error: String? = null
 )

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/MarketScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/screen/MarketScreen.kt
@@ -1,21 +1,16 @@
 package com.delighted2wins.souqelkhorda.features.market.presentation.screen
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Message
-import androidx.compose.material.icons.filled.Sell
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -30,12 +25,15 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.delighted2wins.souqelkhorda.app.theme.Til
 import com.delighted2wins.souqelkhorda.core.components.DirectionalText
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrder
-import com.delighted2wins.souqelkhorda.features.market.domain.entities.ScrapOrderItem
 import com.delighted2wins.souqelkhorda.features.market.domain.entities.User
 import com.delighted2wins.souqelkhorda.features.market.presentation.component.ScrapCard
+import com.delighted2wins.souqelkhorda.features.market.presentation.component.ScrapCardShimmer
 import com.delighted2wins.souqelkhorda.features.market.presentation.component.SearchBar
 import com.delighted2wins.souqelkhorda.features.market.presentation.contract.MarketEffect
 import com.delighted2wins.souqelkhorda.features.market.presentation.contract.MarketIntent
+import com.google.accompanist.swiperefresh.SwipeRefresh
+import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
+import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 
 @Composable
 fun MarketScreen(
@@ -51,465 +49,110 @@ fun MarketScreen(
     LaunchedEffect(Unit) {
         viewModel.effect.collect { effect ->
             when (effect) {
-                is MarketEffect.NavigateToOrderDetails -> {
-                    onDetailsClick(effect.order)
-                }
-                is MarketEffect.ShowError -> {
-                    // TODO: show snackbar or dialog with effect.message
-                }
-                is MarketEffect.NavigateToSellNow -> {
-                    navToAddItem()
-                }
+                is MarketEffect.NavigateToOrderDetails -> { onDetailsClick(effect.order) }
+                is MarketEffect.ShowError -> { /* show snackbar, etc. */ }
+                is MarketEffect.NavigateToSellNow -> { navToAddItem() }
             }
         }
     }
 
-    LazyColumn(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(top = innerPadding.calculateTopPadding()),
-        contentPadding = PaddingValues(16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+    SwipeRefresh(
+        state = rememberSwipeRefreshState(state.isRefreshing),
+        onRefresh = { viewModel.onIntent(MarketIntent.Refresh) },
+        indicator = { state, trigger ->
+            SwipeRefreshIndicator(
+                state = state,
+                refreshTriggerDistance = trigger,
+                backgroundColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary,
+                scale = true,
+            )
+        },
+        modifier = Modifier.padding(innerPadding)
     ) {
-
-        item {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                SearchBar(
-                    query = state.query,
-                    onQueryChange = { viewModel.onIntent(MarketIntent.SearchQueryChanged(it)) },
-                    modifier = Modifier.fillMaxWidth(),
-                    isRtl = isRtl
-                )
-            }
-        }
-
-        item {
-            CompositionLocalProvider(LocalLayoutDirection provides if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr)
-            {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
+        when {
+            state.isLoading -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    DirectionalText(
-                        text = if (isRtl) "العروض المتاحة" else "Available Offers",
-                        contentIsRtl = isRtl,
-                        style = MaterialTheme.typography.titleLarge,
-                        color = Til,
-                        modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
-                    )
-
-                    Spacer(modifier = Modifier.weight(1f))
-
-                    OutlinedButton(
-                        onClick = { viewModel.onIntent(MarketIntent.SellNowClicked) },
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(
-                                imageVector = Icons.Default.Sell,
-                                contentDescription = "sell now"
-                            )
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Text(text = if (isRtl) "بيع الأن" else "Sell Now")
-                        }
-                    }
+                    items(10) { ScrapCardShimmer(systemIsRtl = isRtl) }
                 }
             }
 
-        }
-
-        items(
-            state.scrapOrders.filter {
-                it.date.contains(state.query, ignoreCase = true) || state.query.isBlank()
+            state.error != null -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = if (isRtl) "حدث خطأ" else "Something went wrong",
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodyLarge
+                    )
+                }
             }
-        ) { scrapData ->
-            ScrapCard(
-                user = User(
-                    id = scrapData.userId,
-                    name = "User ${scrapData.userId}",
-                    location = scrapData.location
-                ),
-                scrap = scrapData,
-                onBuyClick = { navigateToMakeOffer() },
-                onDetailsClick = { onDetailsClick(scrapData) },
-                systemIsRtl = isRtl
-            )
-        }
 
-        item {
-            Spacer(modifier = Modifier.padding(60.dp))
+            else -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    item {
+                        SearchBar(
+                            query = state.query,
+                            onQueryChange = { viewModel.onIntent(MarketIntent.SearchQueryChanged(it)) },
+                            modifier = Modifier.fillMaxWidth(),
+                            isRtl = isRtl
+                        )
+                    }
+
+                    item {
+                        CompositionLocalProvider(
+                            LocalLayoutDirection provides if (isRtl) LayoutDirection.Rtl else LayoutDirection.Ltr
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                DirectionalText(
+                                    text = if (isRtl) "العروض المتاحة" else "Available Offers",
+                                    contentIsRtl = isRtl,
+                                    style = MaterialTheme.typography.titleLarge,
+                                    color = Til,
+                                    modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+                                )
+                            }
+                        }
+                    }
+
+                    items(
+                        state.successfulOrders.filter {
+                            it.title.contains(state.query, ignoreCase = true) || state.query.isBlank()
+                        }
+                    ) { scrapData ->
+                        ScrapCard(
+                            user = User(
+                                id = scrapData.userId,
+                                name = "User ${scrapData.userId}",
+                                location = scrapData.location
+                            ),
+                            scrap = scrapData,
+                            onBuyClick = { navigateToMakeOffer() },
+                            onDetailsClick = { onDetailsClick(scrapData) },
+                            systemIsRtl = isRtl
+                        )
+                    }
+
+                    item { Spacer(modifier = Modifier.padding(60.dp)) }
+                }
+            }
         }
     }
 }
-
-
-fun sampleData() = listOf(
-    ScrapOrder(
-        id = 1,
-        title = "Plastic & Aluminum",
-        description = "Mixed scrap materials collected from households." +
-                " Includes plastic bottles and aluminum cans." +
-                " Ready for recycling." +
-                " Contact for pickup arrangements." +
-                " Thank you for supporting recycling efforts!" +
-                " Let's make a greener planet together." +
-                " Every bit counts!" +
-                " Reduce, Reuse, Recycle!" +
-                " Join us in our mission to promote sustainability.",
-        location = "Cairo - Maadi",
-        price = 25.0,
-        date = "2025-09-10",
-        userId = 100,
-        items = listOf(
-            ScrapOrderItem(
-                id = 101,
-                name = "Plastic Bottles",
-                weight = 7,
-                quantity = 3,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=1",
-                    "https://picsum.photos/600/400?random=2",
-                    "https://picsum.photos/600/400?random=22",
-                    "https://picsum.photos/600/400?random=23"
-                )
-            ),
-            ScrapOrderItem(
-                id = 102,
-                name = "Aluminum Cans",
-                weight = 5,
-                quantity = 2,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=3",
-                    "https://picsum.photos/600/400?random=4"
-                )
-            ),
-            ScrapOrderItem(
-                id = 103,
-                name = "Plastic Bags",
-                weight = 2,
-                quantity = null,
-                images = emptyList()
-            ),
-            ScrapOrderItem(
-                id = 104,
-                name = "Plastic Containers",
-                weight = 4,
-                quantity = 4,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=24"
-                )
-            ),
-            ScrapOrderItem(
-                id = 105,
-                name = "Aluminum Foil",
-                weight = 1,
-                quantity = null,
-                images = emptyList()
-            )
-        )
-    ),
-    ScrapOrder(
-        id = 2,
-        title = "ورق وكرتون مكتبي",
-        description = "أوراق مكتبية وكرتون جاهزة لإعادة التدوير.",
-        location = "Giza - Dokki",
-        price = 30.0,
-        date = "2025-09-05",
-        userId = 101,
-        items = listOf(
-            ScrapOrderItem(
-                id = 201,
-                name = "Office Paper",
-                weight = 5,
-                quantity = null,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=5",
-                    "https://picsum.photos/600/400?random=6"
-                )
-            ),
-            ScrapOrderItem(
-                id = 202,
-                name = "Cardboard",
-                weight = 3,
-                quantity = 3,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=7"
-                )
-            )
-        )
-    ),
-    ScrapOrder(
-        id = 3,
-        title = "Iron Scrap",
-        description = "Heavy iron scrap collected from construction sites.",
-        location = "Alexandria",
-        price = 50.0,
-        date = "2025-09-12",
-        userId = 102,
-        items = listOf(
-            ScrapOrderItem(
-                id = 301,
-                name = "Iron Bars",
-                weight = 20,
-                quantity = 5,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=8",
-                    "https://picsum.photos/600/400?random=9"
-                )
-            )
-        )
-    ),
-    ScrapOrder(
-        id = 4,
-        title = "Copper Wires",
-        description = "Electric copper wires removed from old installations.",
-        location = "Cairo - Nasr City",
-        price = 80.0,
-        date = "2025-09-13",
-        userId = 103,
-        items = listOf(
-            ScrapOrderItem(
-                id = 401,
-                name = "Thick Copper Wire",
-                weight = 10,
-                quantity = 2,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=10"
-                )
-            ),
-            ScrapOrderItem(
-                id = 402,
-                name = "Thin Copper Wire",
-                weight = 15,
-                quantity = null,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=11"
-                )
-            )
-        )
-    ),
-    ScrapOrder(
-        id = 5,
-        title = "Mixed Glass",
-        description = "Colored and transparent glass bottles.",
-        location = "Mansoura",
-        price = 15.0,
-        date = "2025-09-01",
-        userId = 104,
-        items = listOf(
-            ScrapOrderItem(
-                id = 501,
-                name = "Green Glass Bottles",
-                weight = 6,
-                quantity = 2,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=12"
-                )
-            ),
-            ScrapOrderItem(
-                id = 502,
-                name = "Transparent Glass Bottles",
-                weight = 8,
-                quantity = 4,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=13"
-                )
-            )
-        )
-    ),
-    ScrapOrder(
-        id = 6,
-        title = "Wooden Pallets",
-        description = "Old wooden pallets from warehouses.",
-        location = "Cairo - Shubra",
-        price = 40.0,
-        date = "2025-08-28",
-        userId = 105,
-        items = listOf(
-            ScrapOrderItem(
-                id = 601,
-                name = "Pallets",
-                weight = 12,
-                quantity = 10,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=14"
-                )
-            )
-        )
-    ),
-    ScrapOrder(
-        id = 7,
-        title = "Old Electronics",
-        description = "E-waste collection of computers and phones.",
-        location = "Cairo - Downtown",
-        price = 120.0,
-        date = "2025-09-11",
-        userId = 106,
-        items = listOf(
-            ScrapOrderItem(
-                id = 701,
-                name = "Old Laptops",
-                weight = 4,
-                quantity = 6,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=15"
-                )
-            ),
-            ScrapOrderItem(
-                id = 702,
-                name = "Mobile Phones",
-                weight = 2,
-                quantity = 10,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=16"
-                )
-            )
-        )
-    ),
-    ScrapOrder(
-        id = 8,
-        title = "Textile Waste",
-        description = "Fabric scraps from tailoring shops.",
-        location = "Cairo - Helwan",
-        price = 10.0,
-        date = "2025-09-03",
-        userId = 107,
-        items = listOf(
-            ScrapOrderItem(
-                id = 801,
-                name = "Cotton Fabric",
-                weight = 5,
-                quantity = 7,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=17"
-                )
-            ),
-            ScrapOrderItem(
-                id = 802,
-                name = "Wool Fabric",
-                weight = 3,
-                quantity = 4,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=18"
-                )
-            )
-        )
-    ),
-    ScrapOrder(
-        id = 9,
-        title = "Plastic Crates",
-        description = "Used crates from vegetable markets.",
-        location = "Beni Suef",
-        price = 18.0,
-        date = "2025-09-08",
-        userId = 108,
-        items = listOf(
-            ScrapOrderItem(
-                id = 901,
-                name = "Large Plastic Crates",
-                weight = 9,
-                quantity = 5,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=19"
-                )
-            )
-        )
-    ),
-    ScrapOrder(
-        id = 10,
-        title = "Mixed Metals",
-        description = "Brass and steel mixed scrap.",
-        location = "Cairo - Obour",
-        price = 90.0,
-        date = "2025-09-14",
-        userId = 109,
-        items = listOf(
-            ScrapOrderItem(
-                id = 1001,
-                name = "Brass Scrap",
-                weight = 7,
-                quantity = 3,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=20"
-                )
-            ),
-            ScrapOrderItem(
-                id = 1002,
-                name = "Steel Scrap",
-                weight = 15,
-                quantity = 6,
-                images = listOf(
-                    "https://picsum.photos/600/400?random=21"
-                )
-            )
-        )
-    )
-)
-
-fun sampleUser() = listOf(
-    User(
-        id = 100,
-        name = "Ahmed Mohamed",
-        location = "Cairo - Maadi",
-        imageUrl = "https://avatar.iran.liara.run/public/boy?username=Ahmed"
-    ),
-    User(
-        id = 101,
-        name = "فاطمة أحمد",
-        location = "Giza - Dokki",
-        imageUrl = "https://avatar.iran.liara.run/public/girl?username=Fatma"
-    ),
-    User(
-        id = 102,
-        name = "Mohamed Ali",
-        location = "Alexandria",
-        imageUrl = "https://avatar.iran.liara.run/public/boy?username=Mohamed"
-    ),
-    User(
-        id = 103,
-        name = "سارة محمود",
-        location = "Tanta",
-        imageUrl = "https://avatar.iran.liara.run/public/girl?username=Sara"
-    ),
-    User(
-        id = 104,
-        name = "Mohamed Mahmoud",
-        location = "Mansoura" // No image URL
-    ),
-    User(
-        id = 105,
-        name = "Youssef Adel",
-        location = "Cairo - Nasr City",
-        imageUrl = "https://avatar.iran.liara.run/public/boy?username=Youssef"
-    ),
-    User(
-        id = 106,
-        name = "Mona Hassan",
-        location = "Giza - Haram",
-        imageUrl = "https://avatar.iran.liara.run/public/girl?username=Mona"
-    ),
-    User(
-        id = 107,
-        name = "Omar Khaled",
-        location = "Cairo - Shubra",
-        imageUrl = "https://avatar.iran.liara.run/public/boy?username=Omar"
-    ),
-    User(
-        id = 108,
-        name = "Layla Ibrahim",
-        location = "Alexandria - Sidi Gaber",
-        imageUrl = "https://avatar.iran.liara.run/public/girl?username=Layla"
-    ),
-    User(
-        id = 109,
-        name = "Hassan Tarek",
-        location = "Cairo - Helwan" // No image URL
-    )
-)
 
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/viewmodel/MarketViewModel.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/market/presentation/viewmodel/MarketViewModel.kt
@@ -34,6 +34,12 @@ class MarketViewModel @Inject constructor(
         when (intent) {
             is MarketIntent.LoadScrapOrders -> loadOrders()
 
+            is MarketIntent.Refresh -> {
+                state = state.copy(isRefreshing = true)
+                loadOrders()
+                state = state.copy(isRefreshing = false)
+            }
+
             is MarketIntent.SearchQueryChanged -> { state = state.copy(query = intent.query) }
 
             is MarketIntent.ClickOrder -> {
@@ -58,7 +64,7 @@ class MarketViewModel @Inject constructor(
                 val orders = getScrapOrdersUseCase()
                 state = state.copy(
                     isLoading = false,
-                    scrapOrders = orders
+                    successfulOrders = orders
                 )
             } catch (e: Exception) {
                 state = state.copy(isLoading = false)

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/screen/OrdersScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/screen/OrdersScreen.kt
@@ -6,11 +6,14 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.Badge
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
@@ -52,12 +55,11 @@ fun OrdersScreen(
             .background(Color.White)
             .padding(innerPadding)
     ) {
-        // Custom styled tabs
         TabRow(
             selectedTabIndex = pagerState.currentPage,
             containerColor = Color.White,
             contentColor = Color.Black,
-            indicator = {} // remove default underline
+            indicator = {}
         ) {
             tabs.forEachIndexed { index, (title, count) ->
                 val isSelected = pagerState.currentPage == index

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/viewmodel/MyOrdersViewModel.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/viewmodel/MyOrdersViewModel.kt
@@ -1,0 +1,11 @@
+package com.delighted2wins.souqelkhorda.features.myorders.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+class MarketViewModel @Inject constructor(
+
+): ViewModel() {
+
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/viewmodel/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/viewmodel/dummy.kt
@@ -1,2 +1,0 @@
-package com.delighted2wins.souqelkhorda.features.myorders.presentation.viewmodel
-

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/orderdetails/presentation/screen/OrderDetailsScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/orderdetails/presentation/screen/OrderDetailsScreen.kt
@@ -34,8 +34,6 @@ import com.delighted2wins.souqelkhorda.features.orderdetails.presentation.compon
 import com.delighted2wins.souqelkhorda.features.orderdetails.presentation.component.OrderDetailsTopBar
 import com.delighted2wins.souqelkhorda.features.orderdetails.presentation.component.OrderItemCard
 import com.delighted2wins.souqelkhorda.features.orderdetails.presentation.component.SellerInfoSection
-import com.delighted2wins.souqelkhorda.features.market.presentation.screen.sampleData
-import com.delighted2wins.souqelkhorda.features.market.presentation.screen.sampleUser
 
 @Composable
 fun OrderDetailsScreen(
@@ -46,7 +44,7 @@ fun OrderDetailsScreen(
     var user by remember { mutableStateOf<User?>(null) }
 
     LaunchedEffect(Unit) {
-       user = sampleUser().firstOrNull{ it.id == order.userId }
+       //user = sampleUser().firstOrNull{ it.id == order.userId }
     }
 
     Surface(
@@ -121,9 +119,9 @@ fun OrderDetailsScreen(
     }
 }
 
-@Preview(showBackground = true, showSystemUi = true)
-@Composable
-fun OrderDetailsScreenPreview() {
-    val sampleOrder = sampleData().first()
-    OrderDetailsScreen(order = sampleOrder)
-}
+//@Preview(showBackground = true, showSystemUi = true)
+//@Composable
+//fun OrderDetailsScreenPreview() {
+//    val sampleOrder = sampleData().first()
+//    OrderDetailsScreen(order = sampleOrder)
+//}


### PR DESCRIPTION
This commit introduces several enhancements to the Market screen:

- **Pull-to-refresh:** Users can now refresh the list of scrap orders by pulling down on the screen.
- **Shimmer effect:** A shimmer loading animation is displayed while fetching data, improving the user experience.
- **State management:**
    - Renamed `scrapOrders` to `successfulOrders` in `MarketState` for clarity.
    - Added `isRefreshing` state to `MarketState` to manage the refresh indicator.
    - Implemented `Refresh` intent in `MarketIntent` and `MarketViewModel` to handle refresh logic.
- **UI improvements:**
    - Integrated `SwipeRefresh` and `ScrapCardShimmer` composables.
    - Removed the "Sell Now" button from the main list items area.
    - Refactored `MarketScreen` to display shimmer, error, or content based on the current state.
- **Code cleanup:**
    - Removed `dummy.kt` from `myorders` feature.
    - Commented out unused preview and sample data in `OrderDetailsScreen`.
    - Minor cleanup in `OrdersScreen`.
- **Dependencies:**
    - Added Accompanist placeholder and swipe-refresh libraries.
- **Firebase:**
    - Ensured `FirebaseFirestore` is provided as a singleton in `FirebaseModule`.
- **New ViewModel:**
    - Created an empty `MyOrdersViewModel.kt`.