### PR TITLE
feat(orders): Enhance OrderType and OrderStatus enums and add History…

### DIFF
--- a/app/src/main/java/com/delighted2wins/souqelkhorda/core/enums/OrderStatus.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/core/enums/OrderStatus.kt
@@ -1,7 +1,39 @@
 package com.delighted2wins.souqelkhorda.core.enums
 
-enum class OrderStatus {
-    PENDING,
-    CANCELLED,
-    COMPLETED
+import androidx.compose.ui.graphics.Color
+import java.util.Locale
+
+enum class OrderStatus(
+    val code: Int,
+    val enValue: String,
+    val arValue: String,
+    val color: Color
+) {
+    PENDING(
+        code = 0,
+        enValue = "Pending",
+        arValue = "قيد الانتظار",
+        color = Color(0xFFFE7E0F)
+    ),
+    CANCELLED(
+        code = 1,
+        enValue = "Cancelled",
+        arValue = "ملغاة",
+        color = Color(0xFFFF1111)
+    ),
+    COMPLETED(
+        code = 2,
+        enValue = "Completed",
+        arValue = "مكتملة",
+        color = Color(0xFF00B259)
+    );
+
+    fun getLocalizedValue(): String {
+        return if (Locale.getDefault().language == "ar") arValue else enValue
+    }
+
+    companion object {
+        fun fromCode(code: Int): OrderStatus =
+            entries.firstOrNull { it.code == code } ?: PENDING
+    }
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/core/enums/OrderType.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/core/enums/OrderType.kt
@@ -1,6 +1,33 @@
 package com.delighted2wins.souqelkhorda.core.enums
 
-enum class OrderType {
-    SALE,
-    MARKET
+import androidx.compose.ui.graphics.Color
+import java.util.Locale
+
+enum class OrderType(
+    val code: Int,
+    val enValue: String,
+    val arValue: String,
+    val color: Color
+) {
+    SALE(
+        code = 0,
+        enValue = "Sale",
+        arValue = "بيع",
+        color = Color(0xFF2A62FF)
+    ),
+    MARKET(
+        code = 1,
+        enValue = "Market",
+        arValue = "سوق",
+        color = Color(0xFF9C27B0)
+    );
+
+    fun getLocalizedValue(): String {
+        return if (Locale.getDefault().language == "ar") arValue else enValue
+    }
+
+    companion object {
+        fun fromCode(code: Int): OrderType =
+            entries.firstOrNull { it.code == code } ?: SALE
+    }
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/history/presentation/state/dummy.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/history/presentation/state/dummy.kt
@@ -1,2 +1,0 @@
-package com.delighted2wins.souqelkhorda.features.history.presentation.state
-

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/history/presentation/viewmodel/HistoryViewModel.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/history/presentation/viewmodel/HistoryViewModel.kt
@@ -1,0 +1,11 @@
+package com.delighted2wins.souqelkhorda.features.history.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class HistoryViewModel @Inject constructor(
+
+): ViewModel() {
+}


### PR DESCRIPTION
…ViewModel

This commit introduces enhancements to the `OrderType` and `OrderStatus` enums and adds a `HistoryViewModel`.

- **OrderType.kt**:
    - Added `code`, `enValue`, `arValue`, and `color` properties to each enum constant.
    - Implemented `getLocalizedValue()` to return the appropriate string based on the device locale.
    - Added a companion object with a `fromCode()` function to retrieve an `OrderType` by its code.
- **OrderStatus.kt**:
    - Added `code`, `enValue`, `arValue`, and `color` properties to each enum constant.
    - Implemented `getLocalizedValue()` to return the appropriate string based on the device locale.
    - Added a companion object with a `fromCode()` function to retrieve an `OrderStatus` by its code.
- **HistoryViewModel.kt**:
    - Created a new `HistoryViewModel` class, annotated with `@HiltViewModel` for Dagger Hilt integration.
    - Renamed and moved from `features.history.presentation.state.dummy.kt`.