### PR TITLE
feat(orders & order-details): Implement company order details and deletion and enhance UI

### DIFF
--- a/app/src/main/java/com/delighted2wins/souqelkhorda/core/model/Scrap.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/core/model/Scrap.kt
@@ -7,5 +7,7 @@ data class Scrap(
     val unit: String = "",
     val amount: String = "0",
     val description: String = "",
-    val images: String = "https://media.wired.com/photos/593261cab8eb31692072f129/3:2/w_2560%2Cc_limit/85120553.jpg"
+    val images: List<String> = listOf(
+        "https://media.wired.com/photos/593261cab8eb31692072f129/3:2/w_2560%2Cc_limit/85120553.jpg"
+    )
 )

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/component/CompanyOrderCard.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/component/CompanyOrderCard.kt
@@ -27,16 +27,14 @@ import com.delighted2wins.souqelkhorda.core.utils.toTimeAgo
 @Composable
 fun CompanyOrderCard(
     order: Order,
-    onClick: (Order) -> Unit,
     onDetailsClick: (String, String) -> Unit,
-    onDeclineClick: () -> Unit,
+    onDeclineClick: (String) -> Unit,
     systemIsRtl: Boolean
 ) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-            .clickable { onClick(order) },
+            .padding(horizontal = 16.dp, vertical = 8.dp),
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surface
@@ -138,7 +136,7 @@ fun CompanyOrderCard(
                     }
 
                     Button(
-                        onClick = onDeclineClick,
+                        onClick = { onDeclineClick(order.orderId) },
                         shape = RoundedCornerShape(8.dp),
                         modifier = Modifier.weight(1f),
                         colors = ButtonDefaults.buttonColors(
@@ -147,7 +145,7 @@ fun CompanyOrderCard(
                         )
                     ) {
                         Text(
-                            text = if (systemIsRtl) "الغاء العرض" else "Decline Offer",
+                            text = if (systemIsRtl) "الغاء الطلب" else "Decline Order",
                             style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold)
                         )
                     }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/component/DeleteConfirmationDialog.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/component/DeleteConfirmationDialog.kt
@@ -1,0 +1,38 @@
+package com.delighted2wins.souqelkhorda.features.myorders.presentation.component
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun DeleteConfirmationDialog(
+    isRtl: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = if (isRtl) "تأكيد الحذف" else "Confirm Delete") },
+        text = { Text(text = if (isRtl) "هل أنت متأكد من حذف الطلب؟" else "Are you sure you want to delete this order?") },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                    contentColor = Color.White
+                )
+            ) {
+                Text(text = if (isRtl) "حذف" else "Delete")
+            }
+        },
+        dismissButton = {
+            Button(onClick = onDismiss) {
+                Text(text = if (isRtl) "إلغاء" else "Cancel")
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/contract/MyOrdersEffect.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/contract/MyOrdersEffect.kt
@@ -3,6 +3,6 @@ package com.delighted2wins.souqelkhorda.features.myorders.presentation.contract
 import com.delighted2wins.souqelkhorda.core.model.Order
 
 sealed class MyOrdersEffect {
-    data class NavigateToOrderDetails(val order: Order): MyOrdersEffect()
+    data class ShowSuccess(val message: String): MyOrdersEffect()
     data class ShowError(val message: String): MyOrdersEffect()
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/contract/MyOrdersIntents.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/contract/MyOrdersIntents.kt
@@ -4,4 +4,8 @@ sealed class MyOrdersIntents{
     object LoadSaleOrders: MyOrdersIntents()
     object LoadOffers: MyOrdersIntents()
     object LoadSells: MyOrdersIntents()
+
+    data class DeleteCompanyOrder(val orderId: String): MyOrdersIntents()
+    data class DeclineOffer(val offerId: String): MyOrdersIntents()
+    data class DeclineSell(val orderId: String): MyOrdersIntents()
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/screen/CompanyOrdersScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/screen/CompanyOrdersScreen.kt
@@ -5,11 +5,15 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MaterialTheme.typography
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.delighted2wins.souqelkhorda.core.components.DirectionalText
 import com.delighted2wins.souqelkhorda.core.model.Order
 
 @Composable
@@ -17,6 +21,8 @@ fun CompanyOrdersScreen(
     orders: List<Order>,
     isLoading: Boolean,
     error: String?,
+    onDetailsClick: (String, String) -> Unit,
+    onDeclineClick: (String) -> Unit,
     systemIsRtl: Boolean
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
@@ -32,12 +38,24 @@ fun CompanyOrdersScreen(
                 }
             }
             error != null -> {
-                Text(
-                    text = error,
+                Box(
                     modifier = Modifier
-                        .align(Alignment.Center)
-                        .padding(16.dp)
-                )
+                        .fillMaxSize()
+                        .padding(16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    DirectionalText(
+                        text = error,
+                        contentIsRtl = systemIsRtl,
+                        style = typography.titleLarge.copy(
+                            color = MaterialTheme.colorScheme.error,
+                            fontWeight = FontWeight.Bold
+                        ),
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(16.dp)
+                    )
+                }
             }
             else -> {
                 LazyColumn(
@@ -47,12 +65,8 @@ fun CompanyOrdersScreen(
                     items(orders) { order ->
                         CompanyOrderCard(
                             order = order,
-                            onClick = {
-                            },
-                            onDetailsClick = { orderId, userId ->
-                            },
-                            onDeclineClick = {
-                            },
+                            onDetailsClick = { orderId, userId -> onDetailsClick(orderId, userId) },
+                            onDeclineClick = { orderId -> onDeclineClick(orderId) },
                             systemIsRtl = systemIsRtl
                         )
                     }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/screen/MarketOrdersScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/screen/MarketOrdersScreen.kt
@@ -19,6 +19,7 @@ import com.delighted2wins.souqelkhorda.features.myorders.presentation.contract.M
 fun MarketOrdersScreen(
     state: MyOrdersState,
     onChipSelected: (String) -> Unit,
+    onDetailsClick: (String, String) -> Unit,
     systemIsRtl: Boolean
 ) {
     var selectedFilter by remember { mutableStateOf("Sells") }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/viewmodel/MyOrdersViewModel.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/myorders/presentation/viewmodel/MyOrdersViewModel.kt
@@ -6,11 +6,15 @@ import androidx.lifecycle.viewModelScope
 import com.delighted2wins.souqelkhorda.features.myorders.domain.usecase.LoadOffersUseCase
 import com.delighted2wins.souqelkhorda.features.myorders.domain.usecase.LoadCompanyOrdersUseCase
 import com.delighted2wins.souqelkhorda.features.myorders.domain.usecase.LoadSellsUseCase
+import com.delighted2wins.souqelkhorda.features.myorders.presentation.contract.MyOrdersEffect
 import com.delighted2wins.souqelkhorda.features.myorders.presentation.contract.MyOrdersIntents
 import com.delighted2wins.souqelkhorda.features.myorders.presentation.contract.MyOrdersState
+import com.delighted2wins.souqelkhorda.features.sell.domain.usecase.DeleteOrderUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -18,21 +22,28 @@ import javax.inject.Inject
 class MyOrdersViewModel @Inject constructor(
     private val loadCompanyOrdersUseCase: LoadCompanyOrdersUseCase,
     private val loadSellsUseCase: LoadSellsUseCase,
-    private val loadOffersUseCase: LoadOffersUseCase
+    private val loadOffersUseCase: LoadOffersUseCase,
+    private val deleteCompanyOrderUseCase: DeleteOrderUseCase
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(MyOrdersState())
     val state: StateFlow<MyOrdersState> = _state
 
+    private val _effect = MutableSharedFlow<MyOrdersEffect>()
+    val effect = _effect.asSharedFlow()
+
     fun onIntent(intent: MyOrdersIntents) {
         when (intent) {
-            is MyOrdersIntents.LoadSaleOrders -> loadSaleOrders()
+            is MyOrdersIntents.LoadSaleOrders -> loadCompanyOrders()
             is MyOrdersIntents.LoadSells -> loadSells()
             is MyOrdersIntents.LoadOffers -> loadOffers()
+            is MyOrdersIntents.DeclineOffer -> declineMyOffer(intent.offerId)
+            is MyOrdersIntents.DeclineSell -> declineMySell(intent.orderId)
+            is MyOrdersIntents.DeleteCompanyOrder -> deleteCompanyOrder(intent.orderId)
         }
     }
 
-    private fun loadSaleOrders() {
+    private fun loadCompanyOrders() {
         viewModelScope.launch {
             _state.value = _state.value.copy(isLoading = true, error = null)
             try {
@@ -89,4 +100,34 @@ class MyOrdersViewModel @Inject constructor(
             }
         }
     }
+
+    private fun deleteCompanyOrder(orderId: String) {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isLoading = true, error = null)
+            try {
+                val isOrderDeclined = deleteCompanyOrderUseCase(orderId)
+                _state.value = _state.value.copy(
+                    isLoading = false,
+                    error = null
+                )
+                loadCompanyOrders()
+                if (isOrderDeclined) {
+                    emitEffect(MyOrdersEffect.ShowSuccess("Order declined successfully"))
+                }
+            } catch (e: Exception) {
+                _state.value = _state.value.copy(
+                    isLoading = false,
+                    error = e.message ?: "Unknown error"
+                )
+                emitEffect(MyOrdersEffect.ShowError(e.message ?: "Unknown error"))
+            }
+        }
+    }
+    private fun declineMyOffer(offerId: String) {}
+    private fun declineMySell(orderId: String) {}
+
+    private fun emitEffect(effect: MyOrdersEffect) {
+        viewModelScope.launch { _effect.emit(effect) }
+    }
+
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/offers/data/remote/OffersRemoteDataSource.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/offers/data/remote/OffersRemoteDataSource.kt
@@ -6,7 +6,7 @@ import com.delighted2wins.souqelkhorda.core.model.Offer
 interface OffersRemoteDataSource {
     suspend fun makeOffer(offer: Offer): String
     suspend fun updateOfferStatus(offerId: String, newStatus: OfferStatus)
-    suspend fun deleteOffer(offerId: String)
+    suspend fun deleteOffer(offerId: String): Boolean
     suspend fun getOfferById(offerId: String): Offer?
     suspend fun getOffersByBuyerId(buyerId: String): List<Offer>
     suspend fun getOffersByOrderId(orderId: String): List<Offer>

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/offers/data/remote/OffersRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/offers/data/remote/OffersRemoteDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.delighted2wins.souqelkhorda.features.offers.data.remote
 
+import android.util.Log
 import com.delighted2wins.souqelkhorda.core.enums.OfferStatus
 import com.delighted2wins.souqelkhorda.core.model.Offer
 import com.google.firebase.firestore.FirebaseFirestore
@@ -25,9 +26,16 @@ class OffersRemoteDataSourceImpl @Inject constructor(
             .await()
     }
 
-    override suspend fun deleteOffer(offerId: String) {
-        offersCollection.document(offerId).delete().await()
+    override suspend fun deleteOffer(offerId: String): Boolean {
+        return try {
+            offersCollection.document(offerId).delete().await()
+            true
+        } catch (e: Exception) {
+            Log.e("OffersRemoteDataSource", "Error deleting offer", e)
+            false
+        }
     }
+
 
     override suspend fun getOfferById(offerId: String): Offer? {
         val snapshot = offersCollection.document(offerId).get().await()

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/offers/data/repository/OffersRepositoryImpl.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/offers/data/repository/OffersRepositoryImpl.kt
@@ -18,8 +18,8 @@ class OffersRepositoryImpl @Inject constructor(
         remoteDataSource.updateOfferStatus(offerId, newStatus)
     }
 
-    override suspend fun deleteOffer(offerId: String) {
-        remoteDataSource.deleteOffer(offerId)
+    override suspend fun deleteOffer(offerId: String): Boolean {
+        return  remoteDataSource.deleteOffer(offerId)
     }
 
     override suspend fun getOfferById(offerId: String): Offer? {

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/offers/domain/repository/OffersRepository.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/offers/domain/repository/OffersRepository.kt
@@ -6,7 +6,7 @@ import com.delighted2wins.souqelkhorda.core.model.Offer
 interface OffersRepository {
     suspend fun makeOffer(offer: Offer): String
     suspend fun updateOfferStatus(offerId: String, newStatus: OfferStatus)
-    suspend fun deleteOffer(offerId: String)
+    suspend fun deleteOffer(offerId: String): Boolean
     suspend fun getOfferById(offerId: String): Offer?
     suspend fun getOffersByBuyerId(buyerId: String): List<Offer>
     suspend fun getOffersByOrderId(orderId: String): List<Offer>

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/offers/domain/usecase/DeleteOfferUseCase.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/offers/domain/usecase/DeleteOfferUseCase.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 class DeleteOfferUseCase @Inject constructor(
     private val repository: OffersRepository
 ) {
-    suspend operator fun invoke(offerId: String) {
-        repository.deleteOffer(offerId)
+    suspend operator fun invoke(offerId: String): Boolean  {
+        return repository.deleteOffer(offerId)
     }
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/orderdetails/data/remote/OrderDetailsRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/orderdetails/data/remote/OrderDetailsRemoteDataSourceImpl.kt
@@ -23,9 +23,14 @@ class OrderDetailsRemoteDataSourceImpl @Inject constructor(
         source: OrderSource
     ): Order? {
         return try {
+            val covert = if (source == OrderSource.COMPANY) {
+                "sale"
+            } else {
+                source.toString().lowercase()
+            }
             val snapshot = firestore
                 .collection("orders")
-                .document(source.toString().lowercase())
+                .document(covert)
                 .collection("items")
                 .document(orderId)
                 .get()

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/orderdetails/presentation/component/OrderItemCard.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/orderdetails/presentation/component/OrderItemCard.kt
@@ -81,7 +81,7 @@ fun OrderItemCard(
                         .padding(16.dp)
                 )
             } else {
-                ZoomableImageList(urls = listOf(item.images))
+                ZoomableImageList(urls = item.images)
             }
         }
     }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/orderdetails/presentation/screen/CompanyOrderDetailsUI.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/orderdetails/presentation/screen/CompanyOrderDetailsUI.kt
@@ -1,0 +1,310 @@
+package com.delighted2wins.souqelkhorda.features.orderdetails.presentation.screen
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Business
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Money
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Receipt
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.delighted2wins.souqelkhorda.core.components.DirectionalText
+import com.delighted2wins.souqelkhorda.core.model.Order
+import com.delighted2wins.souqelkhorda.core.model.Scrap
+import com.delighted2wins.souqelkhorda.core.utils.generateUiOrderId
+import com.delighted2wins.souqelkhorda.features.market.domain.entities.MarketUser
+import com.delighted2wins.souqelkhorda.features.orderdetails.presentation.component.OrderDetailsTopBar
+import java.text.SimpleDateFormat
+import java.util.*
+
+@Composable
+fun CompanyOrderDetailsUI(
+    order: Order,
+    seller: MarketUser?,
+    isRtl: Boolean,
+    onBackClick: () -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+
+        item {
+            OrderDetailsTopBar(
+                title = if (isRtl) "التفاصيل" else "Details",
+                isRtl = isRtl,
+                onBackClick = onBackClick
+            )
+        }
+
+        item {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
+                elevation = CardDefaults.cardElevation(defaultElevation = 3.dp),
+                shape = MaterialTheme.shapes.medium
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Default.Business,
+                            contentDescription = "Company",
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        DirectionalText(
+                            text = if (isRtl) "شركة سوق الخردة" else "Souq El Khorda Company",
+                            style = MaterialTheme.typography.titleLarge,
+                            contentIsRtl = isRtl
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    DirectionalText(
+                        text = if (isRtl) "العنوان: الاسكندرية، مصر" else "Address: Alexandria, Egypt",
+                        style = MaterialTheme.typography.bodyMedium,
+                        contentIsRtl = isRtl
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    DirectionalText(
+                        text = if (isRtl) "البريد: info@souqelkhorda.com" else "Email: info@souqelkhorda.com",
+                        style = MaterialTheme.typography.bodyMedium,
+                        contentIsRtl = isRtl
+                    )
+                }
+            }
+        }
+
+        item {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.secondaryContainer),
+                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+                shape = MaterialTheme.shapes.medium
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Icon(
+                            Icons.Default.Person,
+                            contentDescription = "Person",
+                            tint = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        DirectionalText(
+                            text = if (isRtl) "معلومات البائع" else "Seller Information",
+                            style = MaterialTheme.typography.titleMedium.copy(
+                                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                            ),
+                            contentIsRtl = isRtl
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+                    DirectionalText(
+                        text = seller?.name ?: "-",
+                        style = MaterialTheme.typography.bodyLarge,
+                        contentIsRtl = isRtl
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    DirectionalText(
+                        text = seller?.location ?: "-",
+                        style = MaterialTheme.typography.bodyMedium,
+                        contentIsRtl = isRtl
+                    )
+                }
+            }
+        }
+
+        item {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+                shape = MaterialTheme.shapes.medium
+            ) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    SummaryRow(
+                        icon = { Icon(Icons.Default.Receipt, contentDescription = "Order Id") },
+                        label = if (isRtl) "معرف الطلب" else "Order ID",
+                        value = generateUiOrderId(order.orderId, order.date),
+                        isRtl = isRtl
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    SummaryRow(
+                        icon = { Icon(Icons.Default.DateRange, contentDescription = "Date") },
+                        label = if (isRtl) "التاريخ" else "Date",
+                        value = order.date.toFormattedDate(),
+                        isRtl = isRtl
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    SummaryRow(
+                        icon = { Icon(Icons.Default.Receipt, contentDescription = "Status") },
+                        label = if (isRtl) "الحالة" else "Status",
+                        value = order.status.name,
+                        isRtl = isRtl
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    SummaryRow(
+                        icon = {
+                            Icon(
+                                Icons.Default.Receipt,
+                                contentDescription = "Price",
+                            )
+                        },
+                        label = if (isRtl) "السعر" else "Price",
+                        value = if (order.price == 0) "-" else "${order.price} ${if (isRtl) "جنيه" else "EGP"}",
+                        isRtl = isRtl
+                    )
+                }
+            }
+        }
+
+        item {
+            DirectionalText(
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+                text = if (isRtl) "العناصر" else "Items",
+                style = MaterialTheme.typography.titleLarge,
+                contentIsRtl = isRtl
+            )
+        }
+        items(order.scraps) { scrap ->
+            ScrapItemRow(scrap = scrap, isRtl = isRtl)
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun SummaryRow(
+    icon: @Composable () -> Unit,
+    label: String,
+    value: String,
+    isRtl: Boolean,
+) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        icon()
+        Spacer(modifier = Modifier.width(8.dp))
+        DirectionalText(
+            text = "$label: $value",
+            style = MaterialTheme.typography.bodyLarge,
+            contentIsRtl = isRtl
+        )
+    }
+}
+
+@Composable
+private fun ScrapItemRow(scrap: Scrap, isRtl: Boolean) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        shape = RoundedCornerShape(16.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = if (isRtl) Arrangement.End else Arrangement.Start,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(
+                    Icons.Default.ShoppingCart,
+                    contentDescription = "Category",
+                    tint = MaterialTheme.colorScheme.primary
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+
+//                DirectionalText(
+//                    text = if (isRtl) "الفئة:" else "Category:",
+//                    style = MaterialTheme.typography.labelMedium.copy(
+//                        color = MaterialTheme.colorScheme.onSurfaceVariant
+//                    ),
+//                    contentIsRtl = isRtl
+//                )
+//                Spacer(modifier = Modifier.width(6.dp))
+                DirectionalText(
+                    text = scrap.category,
+                    style = MaterialTheme.typography.bodyLarge,
+                    contentIsRtl = isRtl
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            DirectionalText(
+                text = (if (isRtl) "الكمية: " else "Amount: ") + "${scrap.amount} ${scrap.unit}",
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = MaterialTheme.colorScheme.primary
+                ),
+                contentIsRtl = isRtl
+            )
+
+            if (scrap.description.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(4.dp))
+                DirectionalText(
+                    text = (if (isRtl) "الوصف: " else "Description: ") + scrap.description,
+                    style = MaterialTheme.typography.bodySmall.copy(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    ),
+                    contentIsRtl = isRtl
+                )
+            }
+
+            if (scrap.images.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                DirectionalText(
+                    text = if (isRtl) "الصور:" else "Images:",
+                    style = MaterialTheme.typography.labelMedium.copy(
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    ),
+                    contentIsRtl = isRtl
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    items(scrap.images) { imageUrl ->
+                        AsyncImage(
+                            model = imageUrl,
+                            contentDescription = "Scrap Image",
+                            modifier = Modifier
+                                .size(90.dp)
+                                .clip(RoundedCornerShape(12.dp)),
+                            contentScale = ContentScale.Crop
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun Long.toFormattedDate(): String {
+    val sdf = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault())
+    return sdf.format(Date(this))
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/orderdetails/presentation/screen/OrderDetailsScreen.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/orderdetails/presentation/screen/OrderDetailsScreen.kt
@@ -31,6 +31,7 @@ import com.delighted2wins.souqelkhorda.features.market.domain.entities.MarketUse
 import com.delighted2wins.souqelkhorda.features.market.presentation.component.ShimmerScrapCard
 import com.delighted2wins.souqelkhorda.features.orderdetails.presentation.contract.OrderDetailsIntent
 import com.delighted2wins.souqelkhorda.features.orderdetails.presentation.contract.OrderDetailsState
+import com.delighted2wins.souqelkhorda.features.orderdetails.presentation.screen.CompanyOrderDetailsUI
 import com.delighted2wins.souqelkhorda.features.orderdetails.presentation.screen.MarketOrderDetailsUI
 import com.delighted2wins.souqelkhorda.features.orderdetails.presentation.viewmodel.OrderDetailsViewModel
 
@@ -192,7 +193,7 @@ private fun RenderSuccess(
             MarketOrderDetailsUI(state.order,orderOwner, isRtl, onBackClick)
         }
         is OrderDetailsState.Success.Company -> {
-            //CompanyOrderDetailsUI(state.order, isRtl, onBackClick)
+            CompanyOrderDetailsUI(state.order,orderOwner, isRtl, onBackClick)
         }
         is OrderDetailsState.Success.Sales -> {
            // SalesOrderDetailsUI(state.order, isRtl, onBackClick)

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/data/datasource/OrdersRemoteDataSource.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/data/datasource/OrdersRemoteDataSource.kt
@@ -5,4 +5,5 @@ import com.delighted2wins.souqelkhorda.core.model.Order
 interface OrdersRemoteDataSource {
 
     suspend fun sendOrder(order: Order)
+    suspend fun deleteOrder(orderId: String): Boolean
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/data/datasource/OrdersRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/data/datasource/OrdersRemoteDataSourceImpl.kt
@@ -10,4 +10,8 @@ class OrdersRemoteDataSourceImpl @Inject constructor(
     override suspend fun sendOrder(order: Order) {
         service.sendOrder(order)
     }
+
+    override suspend fun deleteOrder(orderId: String): Boolean {
+        return service.deleteCompanyOrder(orderId)
+    }
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/data/mapper/ScrapMapper.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/data/mapper/ScrapMapper.kt
@@ -11,7 +11,7 @@ fun ScrapEntity.toDomain(): Scrap {
         unit = unit,
         amount = amount,
         description = description,
-        images = images
+        images = listOf(images)
     )
 }
 
@@ -21,6 +21,6 @@ fun Scrap.toEntity(): ScrapEntity {
         unit = unit,
         amount = amount,
         description = description,
-        images = images
+        images = listOf(images).toString()
     )
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/data/remote/firestore/FirestoreOrderService.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/data/remote/firestore/FirestoreOrderService.kt
@@ -1,5 +1,6 @@
 package com.delighted2wins.souqelkhorda.features.sell.data.remote.firestore
 
+import com.delighted2wins.souqelkhorda.core.enums.OrderType
 import com.delighted2wins.souqelkhorda.core.model.Order
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
@@ -29,4 +30,20 @@ class FirestoreOrderService @Inject constructor(
         firestore.collection("history")
             .add(order)
     }
+
+    suspend fun deleteCompanyOrder(orderId: String): Boolean {
+        return try {
+            firestore.collection("orders")
+                .document(OrderType.SALE.name.lowercase())
+                .collection("items")
+                .document(orderId)
+                .delete()
+                .await()
+            true
+        } catch (e: Exception) {
+            e.printStackTrace()
+            false
+        }
+    }
+
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/data/repo/OrderRepositoryImpl.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/data/repo/OrderRepositoryImpl.kt
@@ -11,4 +11,7 @@ class OrderRepositoryImpl @Inject constructor(
     override suspend fun sendOrder(order: Order) {
         remote.sendOrder(order)
     }
+    override suspend fun deleteOrder(orderId: String): Boolean {
+        return remote.deleteOrder(orderId)
+    }
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/di/ScrapUseCaseModule.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/di/ScrapUseCaseModule.kt
@@ -3,6 +3,7 @@ package com.delighted2wins.souqelkhorda.features.sell.di
 import com.delighted2wins.souqelkhorda.features.sell.domain.repo.OrderRepository
 import com.delighted2wins.souqelkhorda.features.sell.domain.repo.ScrapRepository
 import com.delighted2wins.souqelkhorda.features.sell.domain.usecase.DeleteAllScrapsUseCase
+import com.delighted2wins.souqelkhorda.features.sell.domain.usecase.DeleteOrderUseCase
 import com.delighted2wins.souqelkhorda.features.sell.domain.usecase.DeleteScrapByIdUseCase
 import com.delighted2wins.souqelkhorda.features.sell.domain.usecase.GetScrapesUseCase
 import com.delighted2wins.souqelkhorda.features.sell.domain.usecase.SaveScrapUseCase
@@ -33,6 +34,10 @@ object ScrapUseCaseModule {
 
     @Provides
     fun provideSendOrderUseCase(repo: OrderRepository) = SendOrderUseCase(repo)
+
+    @Provides
+    @ViewModelScoped
+    fun provideDeleteOrderUseCase(repo: OrderRepository) = DeleteOrderUseCase(repo)
 
     @Provides
     @ViewModelScoped

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/domain/repo/OrderRepository.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/domain/repo/OrderRepository.kt
@@ -4,4 +4,5 @@ import com.delighted2wins.souqelkhorda.core.model.Order
 
 interface OrderRepository {
     suspend fun sendOrder(order: Order)
+    suspend fun deleteOrder(orderId: String): Boolean
 }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/domain/usecase/DeleteOrderUseCase.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/sell/domain/usecase/DeleteOrderUseCase.kt
@@ -1,0 +1,12 @@
+package com.delighted2wins.souqelkhorda.features.sell.domain.usecase
+
+import com.delighted2wins.souqelkhorda.features.sell.domain.repo.OrderRepository
+import javax.inject.Inject
+
+class DeleteOrderUseCase @Inject constructor(
+    private val orderRepository: OrderRepository
+) {
+    suspend operator fun invoke(orderId: String): Boolean {
+        return orderRepository.deleteOrder(orderId)
+    }
+}

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/navigation/NavigationRoot.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/navigation/NavigationRoot.kt
@@ -169,6 +169,16 @@ fun NavigationRoot(
                         bottomBarState.value = true
                         OrdersScreen(
                             innerPadding,
+                            snackBarState,
+                            onDetailsClick = { orderId, ownerId ->
+                                backStack.add(
+                                    OrderDetailsKey(
+                                        orderId,
+                                        ownerId,
+                                        source = OrderSource.COMPANY
+                                    )
+                                )
+                            }
                         )
                     }
                 }


### PR DESCRIPTION
This commit introduces the following changes:
- Adds functionality to delete company orders, including:
    - `DeleteOrderUseCase` and its Dagger provider.
    - `deleteOrder` method in `OrderRepository`, `OrdersRemoteDataSource`, and their implementations (`FirestoreOrderService`, `OrderRepositoryImpl`, `OrdersRemoteDataSourceImpl`).
    - `DeleteCompanyOrder` intent and handling in `MyOrdersViewModel`.
    - `DeleteConfirmationDialog` composable for user confirmation.
- Modifies `MyOrdersEffect` to include `ShowSuccess` for feedback.
- Updates `MyOrdersViewModel` to handle order deletion, show success/error messages via effects, and load company orders (renamed from sale orders).
- Refactors `OrdersScreen`:
    - Integrates `SnackbarHostState` for displaying effects.
    - Adds navigation to `OrderDetailsScreen` for company orders.
    - Implements delete confirmation dialog flow for company orders.
- Enhances `CompanyOrderCard`:
    - Updates decline button text to "Decline Order".
    - Passes `orderId` to `onDeclineClick`.
- Implements `CompanyOrderDetailsUI` composable for displaying company order details.
- Updates `OrderDetailsScreen` to use `CompanyOrderDetailsUI` for company orders.
- Modifies `OrderDetailsRemoteDataSourceImpl` to correctly fetch company order details (using "sale" as the document ID).
- Changes `Scrap.images` from `String` to `List<String>` and updates mappers accordingly.
- Fixes image display in `OrderItemCard` to use the list of images.
- Updates `OffersRepository`, `OffersRemoteDataSource`, `OffersRemoteDataSourceImpl`, and `DeleteOfferUseCase` to return `Boolean` for deletion status.
- Minor UI improvements in `CompanyOrdersScreen` for error display.
- Passes `onDetailsClick` to `MarketOrdersScreen`.