### PR TITLE
Refactor(notification): Order notifications by creation date

### DIFF
--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/notification/data/remote/NotificationRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/notification/data/remote/NotificationRemoteDataSourceImpl.kt
@@ -23,6 +23,7 @@ class NotificationRemoteDataSourceImpl @Inject constructor(
             val list = firestore.collection("notifications")
                 .document(userId)
                 .collection("userNotifications")
+                .orderBy("createdAt", Query.Direction.DESCENDING)
                 .get()
                 .await()
                 .map { doc ->
@@ -93,7 +94,6 @@ class NotificationRemoteDataSourceImpl @Inject constructor(
         val listener = firestore.collection("notifications")
             .document(userId)
             .collection("userNotifications")
-            .orderBy("timestamp", Query.Direction.DESCENDING)
             .addSnapshotListener { snapshot, error ->
                 if (error != null) {
                     close(error)


### PR DESCRIPTION
This commit updates the notification fetching logic:

- Modifies `getNotifications` in `NotificationRemoteDataSourceImpl.kt` to order notifications by the `createdAt` field in descending order.
- Removes the previous ordering by `timestamp` in the snapshot listener within the same file, as notifications are now consistently ordered by `createdAt`.