### PR TITLE
feat(profile): Prevent updates when no changes are made

### DIFF
--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/history/data/remote/HistoryRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/history/data/remote/HistoryRemoteDataSourceImpl.kt
@@ -7,6 +7,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.SetOptions
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 
 class HistoryRemoteDataSourceImpl @Inject constructor(
     private val firebaseFirestore: FirebaseFirestore,
@@ -23,6 +24,7 @@ class HistoryRemoteDataSourceImpl @Inject constructor(
             val orders = snapshot.documents.mapNotNull { it.toObject(Order::class.java) }
             Result.success(HistoryDto(orders))
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Result.failure(e)
         }
 
@@ -39,6 +41,7 @@ class HistoryRemoteDataSourceImpl @Inject constructor(
                 .await()
             true
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             e.printStackTrace()
             false
         }
@@ -55,6 +58,7 @@ class HistoryRemoteDataSourceImpl @Inject constructor(
                 .await()
             true
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             e.printStackTrace()
             false
         }
@@ -76,6 +80,7 @@ class HistoryRemoteDataSourceImpl @Inject constructor(
             orderRef.set(mapOf("status" to status.name), SetOptions.merge()).await()
             true
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             e.printStackTrace()
             false
         }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/notification/data/remote/NotificationRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/notification/data/remote/NotificationRemoteDataSourceImpl.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 
 class NotificationRemoteDataSourceImpl @Inject constructor(
     private val firestore: FirebaseFirestore,
@@ -34,6 +35,7 @@ class NotificationRemoteDataSourceImpl @Inject constructor(
                 }
             Result.success(list)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Result.failure(e)
         }
     }
@@ -50,6 +52,7 @@ class NotificationRemoteDataSourceImpl @Inject constructor(
                 .size()
             Result.success(count)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Result.failure(e)
         }
     }
@@ -67,6 +70,7 @@ class NotificationRemoteDataSourceImpl @Inject constructor(
                 .await()
             Result.success(Unit)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Result.failure(e)
         }
     }
@@ -84,6 +88,7 @@ class NotificationRemoteDataSourceImpl @Inject constructor(
                 .await()
             Result.success(Unit)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Result.failure(e)
         }
     }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/profile/data/remote/ProfileRemoteDataSourceImpl.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/profile/data/remote/ProfileRemoteDataSourceImpl.kt
@@ -7,6 +7,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 
 class ProfileRemoteDataSourceImpl @Inject constructor(
     private val firebaseAuth: FirebaseAuth,
@@ -32,6 +33,7 @@ class ProfileRemoteDataSourceImpl @Inject constructor(
             updateUserField(userId, "email", email)
             Result.success(Unit)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Result.failure(e)
         }
     }
@@ -74,6 +76,7 @@ class ProfileRemoteDataSourceImpl @Inject constructor(
                 Result.failure(Exception("User not found"))
             }
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Result.failure(e)
         }
     }
@@ -91,6 +94,7 @@ class ProfileRemoteDataSourceImpl @Inject constructor(
             userCollection.document(userId).update(field, value).await()
             Result.success(Unit)
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Result.failure(e)
         }
     }

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/profile/domain/entity/ProfileMessagesEnum.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/profile/domain/entity/ProfileMessagesEnum.kt
@@ -10,6 +10,7 @@ enum class ProfileMessagesEnum(
     UNAUTHORIZED("Unauthorized action", "غير مصرح"),
     USER_NOT_FOUND("User not found", "المستخدم غير موجود"),
     UNKNOWN("Unknown error", "خطأ غير معروف"),
+    NO_CHANGES("No changes made","لا توجد تغييرات لتحديثها"),
 
     NAME_INVALID("Enter a valid name", "أدخل اسمًا صالحًا"),
     EMAIL_INVALID("Enter a valid email", "أدخل بريدًا إلكترونيًا صالحًا"),

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/profile/presentation/component/ProfileHeader.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/profile/presentation/component/ProfileHeader.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -66,13 +67,17 @@ fun ProfileHeader(
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .clip(RoundedCornerShape(bottomEnd = 8.dp))
-                        .background(if (isSystemInDarkTheme()) Color(0xFFFFD54F) else Color(0xFFFFF176))
+                        .background(
+                            if (isSystemInDarkTheme()) Color(0xFFFFD54F) else Color(
+                                0xFFFFF176
+                            )
+                        )
                         .clickable { onBuyerClick() }
                         .padding(horizontal = 10.dp, vertical = 2.dp),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(
-                        text = "Buyer",
+                        text = stringResource(R.string.buyer),
                         color = Color.Black,
                         style = AppTypography.labelSmall.copy(
                             fontWeight = FontWeight.Bold

--- a/app/src/main/java/com/delighted2wins/souqelkhorda/features/profile/presentation/viewmodel/ProfileViewModel.kt
+++ b/app/src/main/java/com/delighted2wins/souqelkhorda/features/profile/presentation/viewmodel/ProfileViewModel.kt
@@ -175,6 +175,17 @@ class ProfileViewModel @Inject constructor(
         successMessage: ProfileMessagesEnum
     ) {
         _state.update { setFieldValue(it, current.copy(isLoading = true)) }
+        if (current.value.trim() == current.originalValue.trim()) {
+            _state.update { setFieldValue(
+                it,
+                current.copy(
+                    isLoading = false,
+                    error = ProfileMessagesEnum.NO_CHANGES.getMsg()
+                )
+            )
+            }
+            return
+        }
         viewModelScope.launch(Dispatchers.IO) {
             val result = update()
             result.onSuccess {

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -305,5 +305,6 @@
     <string name="no_internet_message">لا يوجد إتصال بالانترنت</string>
     <string name="nearest_buyers">التجار القريبين</string>
     <string name="browse_and_purchase_scrap_materials_from_sellers">تصفح واشترِ مواد الخردة من البائعين</string>
+    <string name="buyer">بائع</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">Souq El Khorda</string>
 
+    <string name="forgot_password">Did you forgot your password?</string>
     <string name="sell_screen_title">Sell</string>
     <string name="shop_screen_title">Market</string>
     <string name="orders_screen_title">Orders</string>
@@ -259,6 +260,7 @@
     <string name="order_items">Order Items (%1$d)</string>
     <string name="nearest_buyers">Nearest Buyers</string>
     <string name="browse_and_purchase_scrap_materials_from_sellers">Browse and purchase scrap materials from sellers</string>
+    <string name="buyer">Buyer</string>
 
 
 </resources>


### PR DESCRIPTION
This commit improves the user experience in the profile screen by preventing unnecessary update calls if the user hasn't modified any data. It also includes general code cleanup and enhancements.

- **Profile Update Logic:**
  - `ProfileViewModel` now checks if a field's value has actually changed before initiating an update.
  - A new `NO_CHANGES` message is displayed to the user if they try to save without making any modifications.

- **Exception Handling:**
  - Enhanced `try-catch` blocks in `History`, `Notification`, and `Profile` remote data sources to explicitly re-throw `CancellationException`. This ensures that coroutine cancellations are handled correctly and not swallowed as generic errors.

- **Localization and UI:**
  - Added new strings for `forgot_password` and `buyer`.
  - The "Buyer" label in `ProfileHeader` is now sourced from string resources to support localization.